### PR TITLE
Geometry 31: Standardize Method Names

### DIFF
--- a/commons-geometry-core/src/main/java/org/apache/commons/geometry/core/Vector.java
+++ b/commons-geometry-core/src/main/java/org/apache/commons/geometry/core/Vector.java
@@ -45,14 +45,14 @@ public interface Vector<V extends Vector<V>> extends Spatial {
      * @see <a href="http://mathworld.wolfram.com/L2-Norm.html">L2 Norm</a>
      * @return L<sub>2</sub> norm for the vector
      */
-    double getNorm();
+    double norm();
 
     /** Get the square of the L<sub>2</sub> norm (also known as the Euclidean norm)
      * for the vector. This is equal to the sum of the squares of all vector components.
-     * @see #getNorm()
+     * @see #norm()
      * @return square of the L<sub>2</sub> norm for the vector
      */
-    double getNormSq();
+    double normSq();
 
     /** Returns a vector with the same direction but with the given
      * norm. This is equivalent to calling {@code vec.normalize().scalarMultiply(mag)}
@@ -104,7 +104,7 @@ public interface Vector<V extends Vector<V>> extends Spatial {
      * @param a scalar
      * @return a new vector
      */
-    V scalarMultiply(double a);
+    V multiply(double a);
 
     /** Compute the distance between the instance and another vector.
      * @param v second vector
@@ -116,7 +116,7 @@ public interface Vector<V extends Vector<V>> extends Spatial {
      * <p>Calling this method is equivalent to calling:
      * <code>q.subtract(p).getNormSq()</code> except that no intermediate
      * vector is built</p>
-     * @see #getNormSq()
+     * @see #normSq()
      * @param v second vector
      * @return the square of the distance between the instance and p
      */

--- a/commons-geometry-core/src/main/java/org/apache/commons/geometry/core/Vector.java
+++ b/commons-geometry-core/src/main/java/org/apache/commons/geometry/core/Vector.java
@@ -124,9 +124,9 @@ public interface Vector<V extends Vector<V>> extends Spatial {
 
     /** Compute the dot-product of the instance and another vector.
      * @param v second vector
-     * @return the dot product this &middot; v
+     * @return the dot product (this &middot; v)
      */
-    double dotProduct(V v);
+    double dot(V v);
 
     /** Compute the angular separation between two vectors in radians.
      * @param v other vector

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/internal/Vectors.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/internal/Vectors.java
@@ -60,7 +60,7 @@ public final class Vectors {
      *  or zero
      */
     public static double checkedNorm(final Vector<?> vec) {
-        return checkedNorm(vec.getNorm());
+        return checkedNorm(vec.norm());
     }
 
     /** Get the L<sub>2</sub> norm (commonly known as the Euclidean norm) for the vector

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/internal/Vectors.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/internal/Vectors.java
@@ -99,21 +99,6 @@ public final class Vectors {
         return Math.sqrt(normSq(x1, x2, x3));
     }
 
-    /** Get the L<sub>2</sub> norm (commonly known as the Euclidean norm) for the vector
-     * with the given components. This corresponds to the common notion of vector magnitude
-     * or length and is defined as the square root of the sum of the squares of all vector components.
-     * @param x1 first vector component
-     * @param x2 second vector component
-     * @param x3 third vector component
-     * @param x4 fourth vector component
-     * @return L<sub>2</sub> norm for the vector with the given components
-     * @see <a href="http://mathworld.wolfram.com/L2-Norm.html">L2 Norm</a>
-     */
-    public static double norm(final double x1, final double x2, final double x3, final double x4) {
-        return Math.sqrt(normSq(x1, x2, x3, x4));
-    }
-
-
     /** Get the square of the L<sub>2</sub> norm (also known as the Euclidean norm)
      * for the vector with the given components. This is equal to the sum of the squares of
      * all vector components.
@@ -148,19 +133,5 @@ public final class Vectors {
      */
     public static double normSq(final double x1, final double x2, final double x3) {
         return (x1 * x1) + (x2 * x2) + (x3 * x3);
-    }
-
-    /** Get the square of the L<sub>2</sub> norm (also known as the Euclidean norm)
-     * for the vector with the given components. This is equal to the sum of the squares of
-     * all vector components.
-     * @param x1 first vector component
-     * @param x2 second vector component
-     * @param x3 third vector component
-     * @param x4 fourth vector component
-     * @return square of the L<sub>2</sub> norm for the vector with the given components
-     * @see #norm(double, double, double, double)
-     */
-    public static double normSq(final double x1, final double x2, final double x3, final double x4) {
-        return (x1 * x1) + (x2 * x2) + (x3 * x3) + (x4 * x4);
     }
 }

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/oned/AffineTransformMatrix1D.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/oned/AffineTransformMatrix1D.java
@@ -201,7 +201,7 @@ public final class AffineTransformMatrix1D implements AffineTransformMatrix<Vect
      * @return inverse transform
      * @throws NonInvertibleTransformException if the transform matrix cannot be inverted
      */
-    public AffineTransformMatrix1D getInverse() {
+    public AffineTransformMatrix1D inverse() {
 
         final double det = this.m00;
 

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/oned/Vector1D.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/oned/Vector1D.java
@@ -188,7 +188,7 @@ public class Vector1D extends EuclideanVector<Vector1D> {
 
     /** {@inheritDoc} */
     @Override
-    public double dotProduct(Vector1D v) {
+    public double dot(Vector1D v) {
         return x * v.x;
     }
 

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/oned/Vector1D.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/oned/Vector1D.java
@@ -115,13 +115,13 @@ public class Vector1D extends EuclideanVector<Vector1D> {
 
     /** {@inheritDoc} */
     @Override
-    public double getNorm() {
+    public double norm() {
         return Vectors.norm(x);
     }
 
     /** {@inheritDoc} */
     @Override
-    public double getNormSq() {
+    public double normSq() {
         return Vectors.normSq(x);
     }
 
@@ -170,7 +170,7 @@ public class Vector1D extends EuclideanVector<Vector1D> {
 
     /** {@inheritDoc} */
     @Override
-    public Vector1D scalarMultiply(double a) {
+    public Vector1D multiply(double a) {
         return new Vector1D(a * x);
     }
 
@@ -396,7 +396,7 @@ public class Vector1D extends EuclideanVector<Vector1D> {
 
         /** {@inheritDoc} */
         @Override
-        public double getNorm() {
+        public double norm() {
             return 1;
         }
 
@@ -409,7 +409,7 @@ public class Vector1D extends EuclideanVector<Vector1D> {
         /** {@inheritDoc} */
         @Override
         public Vector1D withNorm(final double mag) {
-            return scalarMultiply(mag);
+            return multiply(mag);
         }
     }
 }

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/AffineTransformMatrix3D.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/AffineTransformMatrix3D.java
@@ -316,7 +316,7 @@ public final class AffineTransformMatrix3D implements AffineTransformMatrix<Vect
      * @return inverse transform
      * @throws NonInvertibleTransformException if the transform matrix cannot be inverted
      */
-    public AffineTransformMatrix3D getInverse() {
+    public AffineTransformMatrix3D inverse() {
 
         // Our full matrix is 4x4 but we can significantly reduce the amount of computations
         // needed here since we know that our last row is [0 0 0 1].

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/Line.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/Line.java
@@ -76,7 +76,7 @@ public class Line implements Embedding<Vector3D, Vector1D> {
             throw new IllegalArgumentException("Points are equal");
         }
         this.direction = Vector3D.linearCombination(1.0 / Math.sqrt(norm2), delta);
-        this.zero = Vector3D.linearCombination(1.0, p1, -p1.dotProduct(delta) / norm2, delta);
+        this.zero = Vector3D.linearCombination(1.0, p1, -p1.dot(delta) / norm2, delta);
     }
 
     /** Get the tolerance below which points are considered identical.
@@ -117,7 +117,7 @@ public class Line implements Embedding<Vector3D, Vector1D> {
      * @return abscissa of the point
      */
     public double getAbscissa(final Vector3D point) {
-        return point.subtract(zero).dotProduct(direction);
+        return point.subtract(zero).dot(direction);
     }
 
     /** Get one point from the line.
@@ -174,7 +174,7 @@ public class Line implements Embedding<Vector3D, Vector1D> {
      */
     public double distance(final Vector3D p) {
         final Vector3D d = p.subtract(zero);
-        final Vector3D n = Vector3D.linearCombination(1.0, d, -d.dotProduct(direction), direction);
+        final Vector3D n = Vector3D.linearCombination(1.0, d, -d.dot(direction), direction);
         return n.norm();
     }
 
@@ -184,7 +184,7 @@ public class Line implements Embedding<Vector3D, Vector1D> {
      */
     public double distance(final Line line) {
 
-        final Vector3D normal = direction.crossProduct(line.direction);
+        final Vector3D normal = direction.cross(line.direction);
         final double n = normal.norm();
         if (n < Precision.SAFE_MIN) {
             // lines are parallel
@@ -192,7 +192,7 @@ public class Line implements Embedding<Vector3D, Vector1D> {
         }
 
         // signed separation of the two parallel planes that contains the lines
-        final double offset = line.zero.subtract(zero).dotProduct(normal) / n;
+        final double offset = line.zero.subtract(zero).dot(normal) / n;
 
         return Math.abs(offset);
 
@@ -204,7 +204,7 @@ public class Line implements Embedding<Vector3D, Vector1D> {
      */
     public Vector3D closestPoint(final Line line) {
 
-        final double cos = direction.dotProduct(line.direction);
+        final double cos = direction.dot(line.direction);
         final double n = 1 - cos * cos;
         if (n < Precision.EPSILON) {
             // the lines are parallel
@@ -212,8 +212,8 @@ public class Line implements Embedding<Vector3D, Vector1D> {
         }
 
         final Vector3D delta0 = line.zero.subtract(zero);
-        final double a        = delta0.dotProduct(direction);
-        final double b        = delta0.dotProduct(line.direction);
+        final double a        = delta0.dot(direction);
+        final double b        = delta0.dot(line.direction);
 
         return Vector3D.linearCombination(1, zero, (a - b * cos) / n, direction);
 

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/Line.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/Line.java
@@ -71,7 +71,7 @@ public class Line implements Embedding<Vector3D, Vector1D> {
      */
     public void reset(final Vector3D p1, final Vector3D p2) {
         final Vector3D delta = p2.subtract(p1);
-        final double norm2 = delta.getNormSq();
+        final double norm2 = delta.normSq();
         if (norm2 == 0.0) {
             throw new IllegalArgumentException("Points are equal");
         }
@@ -175,7 +175,7 @@ public class Line implements Embedding<Vector3D, Vector1D> {
     public double distance(final Vector3D p) {
         final Vector3D d = p.subtract(zero);
         final Vector3D n = Vector3D.linearCombination(1.0, d, -d.dotProduct(direction), direction);
-        return n.getNorm();
+        return n.norm();
     }
 
     /** Compute the shortest distance between the instance and another line.
@@ -185,7 +185,7 @@ public class Line implements Embedding<Vector3D, Vector1D> {
     public double distance(final Line line) {
 
         final Vector3D normal = direction.crossProduct(line.direction);
-        final double n = normal.getNorm();
+        final double n = normal.norm();
         if (n < Precision.SAFE_MIN) {
             // lines are parallel
             return distance(line.zero);

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/OutlineExtractor.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/OutlineExtractor.java
@@ -49,7 +49,7 @@ public class OutlineExtractor {
     public OutlineExtractor(final Vector3D u, final Vector3D v) {
         this.u = u;
         this.v = v;
-        this.w = u.crossProduct(v);
+        this.w = u.cross(v);
     }
 
     /** Extract the outline of a polyhedrons set.
@@ -168,7 +168,7 @@ public class OutlineExtractor {
                 (AbstractSubHyperplane<Vector3D, Vector2D>) facet;
             final Plane plane    = (Plane) facet.getHyperplane();
 
-            final double scal = plane.getNormal().dotProduct(w);
+            final double scal = plane.getNormal().dot(w);
             if (Math.abs(scal) > 1.0e-3) {
                 Vector2D[][] vertices =
                     ((PolygonsSet) absFacet.getRemainingRegion()).getVertices();
@@ -205,13 +205,13 @@ public class OutlineExtractor {
                     int previous         = closed ? (loop.length - 1) : 1;
                     Vector3D previous3D  = plane.toSpace(loop[previous]);
                     int current          = (previous + 1) % loop.length;
-                    Vector2D pPoint       = Vector2D.of(previous3D.dotProduct(u),
-                                                         previous3D.dotProduct(v));
+                    Vector2D pPoint       = Vector2D.of(previous3D.dot(u),
+                                                         previous3D.dot(v));
                     while (current < loop.length) {
 
                         final Vector3D current3D = plane.toSpace(loop[current]);
-                        final Vector2D  cPoint    = Vector2D.of(current3D.dotProduct(u),
-                                                                 current3D.dotProduct(v));
+                        final Vector2D  cPoint    = Vector2D.of(current3D.dot(u),
+                                                                 current3D.dot(v));
                         final org.apache.commons.geometry.euclidean.twod.Line line =
                             new org.apache.commons.geometry.euclidean.twod.Line(pPoint, cPoint, tolerance);
                         SubHyperplane<Vector2D> edge = line.wholeHyperplane();

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/Plane.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/Plane.java
@@ -339,7 +339,7 @@ public class Plane implements Hyperplane<Vector3D>, Embedding<Vector3D, Vector2D
      */
     public Line intersection(final Plane other) {
         final Vector3D direction = w.crossProduct(other.w);
-        if (direction.getNorm() < tolerance) {
+        if (direction.norm() < tolerance) {
             return null;
         }
         final Vector3D point = intersection(this, other, new Plane(direction, tolerance));

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/Plane.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/Plane.java
@@ -70,7 +70,7 @@ public class Plane implements Hyperplane<Vector3D>, Embedding<Vector3D, Vector2D
         throws IllegalArgumentException {
         setNormal(normal);
         this.tolerance = tolerance;
-        this.originOffset = -p.dotProduct(w);
+        this.originOffset = -p.dot(w);
         setFrame();
     }
 
@@ -85,7 +85,7 @@ public class Plane implements Hyperplane<Vector3D>, Embedding<Vector3D, Vector2D
      */
     public Plane(final Vector3D p1, final Vector3D p2, final Vector3D p3, final double tolerance)
         throws IllegalArgumentException {
-        this(p1, p2.subtract(p1).crossProduct(p3.subtract(p1)), tolerance);
+        this(p1, p2.subtract(p1).cross(p3.subtract(p1)), tolerance);
     }
 
     /** Copy constructor.
@@ -121,7 +121,7 @@ public class Plane implements Hyperplane<Vector3D>, Embedding<Vector3D, Vector2D
      */
     public void reset(final Vector3D p, final Vector3D normal) {
         setNormal(normal);
-        originOffset = -p.dotProduct(w);
+        originOffset = -p.dot(w);
         setFrame();
     }
 
@@ -154,7 +154,7 @@ public class Plane implements Hyperplane<Vector3D>, Embedding<Vector3D, Vector2D
     private void setFrame() {
         origin = Vector3D.linearCombination(-originOffset, w);
         u = w.orthogonal();
-        v = w.crossProduct(u);
+        v = w.cross(u);
     }
 
     /** Get the origin point of the plane frame.
@@ -242,7 +242,7 @@ public class Plane implements Hyperplane<Vector3D>, Embedding<Vector3D, Vector2D
     @Override
     public Vector2D toSubSpace(final Vector3D point) {
         Vector3D vec = point;
-        return Vector2D.of(vec.dotProduct(u), vec.dotProduct(v));
+        return Vector2D.of(vec.dot(u), vec.dot(v));
     }
 
     /** Transform an in-plane point into a 3D space point.
@@ -323,12 +323,12 @@ public class Plane implements Hyperplane<Vector3D>, Embedding<Vector3D, Vector2D
      */
     public Vector3D intersection(final Line line) {
         final Vector3D direction = line.getDirection();
-        final double   dot       = w.dotProduct(direction);
+        final double   dot       = w.dot(direction);
         if (Math.abs(dot) < 1.0e-10) {
             return null;
         }
         final Vector3D point = line.toSpace(Vector1D.ZERO);
-        final double   k     = -(originOffset + w.dotProduct(point)) / dot;
+        final double   k     = -(originOffset + w.dot(point)) / dot;
         return Vector3D.linearCombination(1.0, point, k, direction);
     }
 
@@ -338,7 +338,7 @@ public class Plane implements Hyperplane<Vector3D>, Embedding<Vector3D, Vector2D
      * other plane (really a {@link Line Line} instance)
      */
     public Line intersection(final Plane other) {
-        final Vector3D direction = w.crossProduct(other.w);
+        final Vector3D direction = w.cross(other.w);
         if (direction.norm() < tolerance) {
             return null;
         }
@@ -437,7 +437,7 @@ public class Plane implements Hyperplane<Vector3D>, Embedding<Vector3D, Vector2D
      */
     @Override
     public double getOffset(final Vector3D point) {
-        return point.dotProduct(w) + originOffset;
+        return point.dot(w) + originOffset;
     }
 
     /** Check if the instance has the same orientation as another hyperplane.
@@ -447,7 +447,7 @@ public class Plane implements Hyperplane<Vector3D>, Embedding<Vector3D, Vector2D
      */
     @Override
     public boolean sameOrientationAs(final Hyperplane<Vector3D> other) {
-        return (((Plane) other).w).dotProduct(w) > 0.0;
+        return (((Plane) other).w).dot(w) > 0.0;
     }
 
 }

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/PolyhedronsSet.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/PolyhedronsSet.java
@@ -450,7 +450,7 @@ public class PolyhedronsSet extends AbstractRegion<Vector3D, Vector2D> {
 
                 // the volume here is actually 3x the actual pyramid volume; we'll apply
                 // the final scaling all at once at the end
-                double scaledVolume = area * facetBarycenter.dotProduct(plane.getNormal());
+                double scaledVolume = area * facetBarycenter.dot(plane.getNormal());
                 if (reversed) {
                     scaledVolume = -scaledVolume;
                 }

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/SubPlane.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/SubPlane.java
@@ -74,8 +74,8 @@ public class SubPlane extends AbstractSubHyperplane<Vector3D, Vector2D> {
         // the hyperplanes do intersect
         Vector2D p = thisPlane.toSubSpace(inter.toSpace(Vector1D.ZERO));
         Vector2D q = thisPlane.toSubSpace(inter.toSpace(Vector1D.ONE));
-        Vector3D crossP = inter.getDirection().crossProduct(thisPlane.getNormal());
-        if (crossP.dotProduct(otherPlane.getNormal()) < 0) {
+        Vector3D crossP = inter.getDirection().cross(thisPlane.getNormal());
+        if (crossP.dot(otherPlane.getNormal()) < 0) {
             final Vector2D tmp = p;
             p           = q;
             q           = tmp;

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/Vector3D.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/Vector3D.java
@@ -162,13 +162,13 @@ public class Vector3D extends MultiDimensionalEuclideanVector<Vector3D> {
 
     /** {@inheritDoc} */
     @Override
-    public double getNorm() {
+    public double norm() {
         return Vectors.norm(x, y, z);
     }
 
     /** {@inheritDoc} */
     @Override
-    public double getNormSq() {
+    public double normSq() {
         return Vectors.normSq(x, y, z);
     }
 
@@ -238,7 +238,7 @@ public class Vector3D extends MultiDimensionalEuclideanVector<Vector3D> {
 
     /** {@inheritDoc} */
     @Override
-    public Vector3D scalarMultiply(double a) {
+    public Vector3D multiply(double a) {
         return new Vector3D(a * x, a * y, a * z);
     }
 
@@ -292,9 +292,9 @@ public class Vector3D extends MultiDimensionalEuclideanVector<Vector3D> {
             // the vectors are almost aligned, compute using the sine
             Vector3D cross = crossProduct(v);
             if (dot >= 0) {
-                return Math.asin(cross.getNorm() / normProduct);
+                return Math.asin(cross.norm() / normProduct);
             }
-            return Math.PI - Math.asin(cross.getNorm() / normProduct);
+            return Math.PI - Math.asin(cross.norm() / normProduct);
         }
 
         // the vectors are sufficiently separated to use the cosine
@@ -447,7 +447,7 @@ public class Vector3D extends MultiDimensionalEuclideanVector<Vector3D> {
         // directly. This will produce the same error result as checking the actual norm since
         // Math.sqrt(0.0) == 0.0, Math.sqrt(Double.NaN) == Double.NaN and
         // Math.sqrt(Double.POSITIVE_INFINITY) == Double.POSITIVE_INFINITY.
-        final double baseMagSq = Vectors.checkedNorm(base.getNormSq());
+        final double baseMagSq = Vectors.checkedNorm(base.normSq());
 
         final double scale = aDotB / baseMagSq;
 
@@ -607,7 +607,7 @@ public class Vector3D extends MultiDimensionalEuclideanVector<Vector3D> {
 
         /** {@inheritDoc} */
         @Override
-        public double getNorm() {
+        public double norm() {
             return 1;
         }
 
@@ -620,7 +620,7 @@ public class Vector3D extends MultiDimensionalEuclideanVector<Vector3D> {
         /** {@inheritDoc} */
         @Override
         public Vector3D withNorm(final double mag) {
-            return scalarMultiply(mag);
+            return multiply(mag);
         }
     }
 }

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/Vector3D.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/Vector3D.java
@@ -271,7 +271,7 @@ public class Vector3D extends MultiDimensionalEuclideanVector<Vector3D> {
      * @see LinearCombination#value(double, double, double, double, double, double)
      */
     @Override
-    public double dotProduct(Vector3D v) {
+    public double dot(Vector3D v) {
         return LinearCombination.value(x, v.x, y, v.y, z, v.z);
     }
 
@@ -286,11 +286,11 @@ public class Vector3D extends MultiDimensionalEuclideanVector<Vector3D> {
     public double angle(Vector3D v) {
         double normProduct = getCheckedNorm() * v.getCheckedNorm();
 
-        double dot = dotProduct(v);
+        double dot = dot(v);
         double threshold = normProduct * 0.99;
         if ((dot < -threshold) || (dot > threshold)) {
             // the vectors are almost aligned, compute using the sine
-            Vector3D cross = crossProduct(v);
+            Vector3D cross = cross(v);
             if (dot >= 0) {
                 return Math.asin(cross.norm() / normProduct);
             }
@@ -354,7 +354,7 @@ public class Vector3D extends MultiDimensionalEuclideanVector<Vector3D> {
      * @param v other vector
      * @return the cross product this ^ v as a new Vector3D
      */
-    public Vector3D crossProduct(final Vector3D v) {
+    public Vector3D cross(final Vector3D v) {
         return new Vector3D(LinearCombination.value(y, v.z, -z, v.y),
                             LinearCombination.value(z, v.x, -x, v.z),
                             LinearCombination.value(x, v.y, -y, v.x));
@@ -439,7 +439,7 @@ public class Vector3D extends MultiDimensionalEuclideanVector<Vector3D> {
      * @throws IllegalNormException if {@code base} has a zero, NaN, or infinite norm
      */
     private Vector3D getComponent(Vector3D base, boolean reject, DoubleFunction3N<Vector3D> factory) {
-        final double aDotB = dotProduct(base);
+        final double aDotB = dot(base);
 
         // We need to check the norm value here to ensure that it's legal. However, we don't
         // want to incur the cost or floating point error of getting the actual norm and then

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/rotation/QuaternionRotation.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/rotation/QuaternionRotation.java
@@ -118,7 +118,7 @@ public final class QuaternionRotation implements Rotation3D, Serializable {
      * @return the negation (inverse) of the rotation
      */
     @Override
-    public QuaternionRotation getInverse() {
+    public QuaternionRotation inverse() {
         return new QuaternionRotation(quat.conjugate());
     }
 
@@ -382,7 +382,7 @@ public final class QuaternionRotation implements Rotation3D, Serializable {
         // if it were the first rotation in the inverse (which it would be).
 
         final Vector3D vec3 = apply(axis3);
-        final Vector3D invVec1 = getInverse().apply(axis1);
+        final Vector3D invVec1 = inverse().apply(axis1);
 
         final double angle2Sin = vec3.dotProduct(axis2.crossProduct(axis3));
 
@@ -448,7 +448,7 @@ public final class QuaternionRotation implements Rotation3D, Serializable {
         final Vector3D crossAxis = axis1.crossProduct(axis2);
 
         final Vector3D vec1 = apply(axis1);
-        final Vector3D invVec1 = getInverse().apply(axis1);
+        final Vector3D invVec1 = inverse().apply(axis1);
 
         final double angle2Cos = vec1.dotProduct(axis1);
 

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/rotation/QuaternionRotation.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/rotation/QuaternionRotation.java
@@ -384,15 +384,15 @@ public final class QuaternionRotation implements Rotation3D, Serializable {
         final Vector3D vec3 = apply(axis3);
         final Vector3D invVec1 = inverse().apply(axis1);
 
-        final double angle2Sin = vec3.dotProduct(axis2.crossProduct(axis3));
+        final double angle2Sin = vec3.dot(axis2.cross(axis3));
 
         if (angle2Sin < -AXIS_ANGLE_SINGULARITY_THRESHOLD ||
                 angle2Sin > AXIS_ANGLE_SINGULARITY_THRESHOLD) {
 
             final Vector3D vec2 = apply(axis2);
 
-            final double angle1TanY = vec2.dotProduct(axis1.crossProduct(axis2));
-            final double angle1TanX = vec2.dotProduct(axis2);
+            final double angle1TanY = vec2.dot(axis1.cross(axis2));
+            final double angle1TanX = vec2.dot(axis2);
 
             final double angle2 = angle2Sin > AXIS_ANGLE_SINGULARITY_THRESHOLD ? Geometry.HALF_PI : Geometry.MINUS_HALF_PI;
 
@@ -403,13 +403,13 @@ public final class QuaternionRotation implements Rotation3D, Serializable {
             };
         }
 
-        final Vector3D  crossAxis13 = axis1.crossProduct(axis3);
+        final Vector3D  crossAxis13 = axis1.cross(axis3);
 
-        final double angle1TanY = vec3.dotProduct(crossAxis13);
-        final double angle1TanX = vec3.dotProduct(axis3);
+        final double angle1TanY = vec3.dot(crossAxis13);
+        final double angle1TanX = vec3.dot(axis3);
 
-        final double angle3TanY = invVec1.dotProduct(crossAxis13);
-        final double angle3TanX = invVec1.dotProduct(axis1);
+        final double angle3TanY = invVec1.dot(crossAxis13);
+        final double angle3TanX = invVec1.dot(axis1);
 
         return new double[] {
             Math.atan2(angle1TanY, angle1TanX),
@@ -445,20 +445,20 @@ public final class QuaternionRotation implements Rotation3D, Serializable {
         // Use the same overall approach as with the Tait-Bryan angles: get the first two angles by looking
         // at the transformed rotation axes and the third by using the inverse.
 
-        final Vector3D crossAxis = axis1.crossProduct(axis2);
+        final Vector3D crossAxis = axis1.cross(axis2);
 
         final Vector3D vec1 = apply(axis1);
         final Vector3D invVec1 = inverse().apply(axis1);
 
-        final double angle2Cos = vec1.dotProduct(axis1);
+        final double angle2Cos = vec1.dot(axis1);
 
         if (angle2Cos < -AXIS_ANGLE_SINGULARITY_THRESHOLD ||
                 angle2Cos > AXIS_ANGLE_SINGULARITY_THRESHOLD) {
 
             final Vector3D vec2 = apply(axis2);
 
-            final double angle1TanY = vec2.dotProduct(crossAxis);
-            final double angle1TanX = vec2.dotProduct(axis2);
+            final double angle1TanY = vec2.dot(crossAxis);
+            final double angle1TanX = vec2.dot(axis2);
 
             final double angle2 = angle2Cos > AXIS_ANGLE_SINGULARITY_THRESHOLD ? Geometry.ZERO_PI : Geometry.PI;
 
@@ -469,11 +469,11 @@ public final class QuaternionRotation implements Rotation3D, Serializable {
             };
         }
 
-        final double angle1TanY = vec1.dotProduct(axis2);
-        final double angle1TanX = -vec1.dotProduct(crossAxis);
+        final double angle1TanY = vec1.dot(axis2);
+        final double angle1TanX = -vec1.dot(crossAxis);
 
-        final double angle3TanY = invVec1.dotProduct(axis2);
-        final double angle3TanX = invVec1.dotProduct(crossAxis);
+        final double angle3TanY = invVec1.dot(axis2);
+        final double angle3TanX = invVec1.dot(crossAxis);
 
         return new double[] {
             Math.atan2(angle1TanY, angle1TanX),
@@ -599,7 +599,7 @@ public final class QuaternionRotation implements Rotation3D, Serializable {
     public static QuaternionRotation createVectorRotation(final Vector3D u, final Vector3D v) {
 
         double normProduct  = Vectors.checkedNorm(u) * Vectors.checkedNorm(v);
-        double dot = u.dotProduct(v);
+        double dot = u.dot(v);
 
         if (dot < ANTIPARALLEL_DOT_THRESHOLD * normProduct) {
             // Special case where u1 = -u2:
@@ -634,7 +634,7 @@ public final class QuaternionRotation implements Rotation3D, Serializable {
         //
         // This can be simplified to the expression below.
         final double vectorialScaleFactor = 1.0 / (2.0 * w * normProduct);
-        final Vector3D axis = u.crossProduct(v);
+        final Vector3D axis = u.cross(v);
 
         return of(w,
                   vectorialScaleFactor * axis.getX(),
@@ -666,11 +666,11 @@ public final class QuaternionRotation implements Rotation3D, Serializable {
         // calculate orthonormalized bases
         final Vector3D a = u1.normalize();
         final Vector3D b = a.orthogonal(u2);
-        final Vector3D c = a.crossProduct(b);
+        final Vector3D c = a.cross(b);
 
         final Vector3D d = v1.normalize();
         final Vector3D e = d.orthogonal(v2);
-        final Vector3D f = d.crossProduct(e);
+        final Vector3D f = d.cross(e);
 
         // create an orthogonal rotation matrix representing the change of basis; this matrix will
         // be the multiplication of the matrix composed of the column vectors d, e, f and the

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/rotation/Rotation3D.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/rotation/Rotation3D.java
@@ -60,7 +60,7 @@ public interface Rotation3D extends Transform<Vector3D, Vector2D> {
     /** Get the inverse rotation.
      * @return the inverse rotation.
      */
-    Rotation3D getInverse();
+    Rotation3D inverse();
 
     /** {@inheritDoc}
      * This operation is not supported. See GEOMETRY-24.

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/rotation/Rotation3D.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/rotation/Rotation3D.java
@@ -27,6 +27,15 @@ import org.apache.commons.geometry.euclidean.twod.Vector2D;
  */
 public interface Rotation3D extends Transform<Vector3D, Vector2D> {
 
+    /** Apply this rotation to the given argument. Since rotations do
+     * not affect vector magnitudes, this method can be applied to
+     * both points and vectors.
+     * @param vec the point or vector to rotate
+     * @return a new instance representing the rotated point or vector
+     */
+    @Override
+    Vector3D apply(Vector3D vec);
+
     /** Get the axis of rotation as a normalized {@link Vector3D}.
      *
      * <p>All 3-dimensional rotations and sequences of rotations can be reduced

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/AffineTransformMatrix2D.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/AffineTransformMatrix2D.java
@@ -276,7 +276,7 @@ public final class AffineTransformMatrix2D implements AffineTransformMatrix<Vect
      * @return inverse transform
      * @throws NonInvertibleTransformException if the transform matrix cannot be inverted
      */
-    public AffineTransformMatrix2D getInverse() {
+    public AffineTransformMatrix2D inverse() {
 
         // Our full matrix is 3x3 but we can significantly reduce the amount of computations
         // needed here since we know that our last row is [0 0 1].

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/Vector2D.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/Vector2D.java
@@ -219,7 +219,7 @@ public class Vector2D extends MultiDimensionalEuclideanVector<Vector2D> {
 
     /** {@inheritDoc} */
     @Override
-    public double dotProduct(Vector2D v) {
+    public double dot(Vector2D v) {
         return LinearCombination.value(x, v.x, y, v.y);
     }
 
@@ -234,7 +234,7 @@ public class Vector2D extends MultiDimensionalEuclideanVector<Vector2D> {
     public double angle(Vector2D v) {
         double normProduct = getCheckedNorm() * v.getCheckedNorm();
 
-        double dot = dotProduct(v);
+        double dot = dot(v);
         double threshold = normProduct * 0.9999;
         if ((dot < -threshold) || (dot > threshold)) {
             // the vectors are almost aligned, compute using the sine
@@ -301,7 +301,7 @@ public class Vector2D extends MultiDimensionalEuclideanVector<Vector2D> {
      *
      * @see <a href="http://mathworld.wolfram.com/CrossProduct.html">Cross product (Mathworld)</a>
      */
-    public double crossProduct(final Vector2D p1, final Vector2D p2) {
+    public double cross(final Vector2D p1, final Vector2D p2) {
         final double x1 = p2.x - p1.x;
         final double y1 = y - p1.y;
         final double x2 = x - p1.x;
@@ -389,7 +389,7 @@ public class Vector2D extends MultiDimensionalEuclideanVector<Vector2D> {
      * @throws IllegalNormException if {@code base} has a zero, NaN, or infinite norm
      */
     private Vector2D getComponent(Vector2D base, boolean reject, DoubleFunction2N<Vector2D> factory) {
-        final double aDotB = dotProduct(base);
+        final double aDotB = dot(base);
 
         // We need to check the norm value here to ensure that it's legal. However, we don't
         // want to incur the cost or floating point error of getting the actual norm and then

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/Vector2D.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/Vector2D.java
@@ -142,13 +142,13 @@ public class Vector2D extends MultiDimensionalEuclideanVector<Vector2D> {
 
     /** {@inheritDoc} */
     @Override
-    public double getNorm() {
+    public double norm() {
         return Vectors.norm(x, y);
     }
 
     /** {@inheritDoc} */
     @Override
-    public double getNormSq() {
+    public double normSq() {
         return Vectors.normSq(x, y);
     }
 
@@ -201,7 +201,7 @@ public class Vector2D extends MultiDimensionalEuclideanVector<Vector2D> {
 
     /** {@inheritDoc} */
     @Override
-    public Vector2D scalarMultiply(double a) {
+    public Vector2D multiply(double a) {
         return new Vector2D(a * x, a * y);
     }
 
@@ -397,7 +397,7 @@ public class Vector2D extends MultiDimensionalEuclideanVector<Vector2D> {
         // directly. This will produce the same error result as checking the actual norm since
         // Math.sqrt(0.0) == 0.0, Math.sqrt(Double.NaN) == Double.NaN and
         // Math.sqrt(Double.POSITIVE_INFINITY) == Double.POSITIVE_INFINITY.
-        final double baseMagSq = Vectors.checkedNorm(base.getNormSq());
+        final double baseMagSq = Vectors.checkedNorm(base.normSq());
 
         final double scale = aDotB / baseMagSq;
 
@@ -550,7 +550,7 @@ public class Vector2D extends MultiDimensionalEuclideanVector<Vector2D> {
 
         /** {@inheritDoc} */
         @Override
-        public double getNorm() {
+        public double norm() {
             return 1;
         }
 
@@ -563,7 +563,7 @@ public class Vector2D extends MultiDimensionalEuclideanVector<Vector2D> {
         /** {@inheritDoc} */
         @Override
         public Vector2D withNorm(final double mag) {
-            return scalarMultiply(mag);
+            return multiply(mag);
         }
     }
 }

--- a/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/internal/VectorsTest.java
+++ b/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/internal/VectorsTest.java
@@ -23,7 +23,6 @@ import org.apache.commons.geometry.euclidean.threed.Vector3D;
 import org.junit.Assert;
 import org.junit.Test;
 
-
 public class VectorsTest {
 
     private static final double EPS = Math.ulp(1d);
@@ -124,18 +123,6 @@ public class VectorsTest {
     }
 
     @Test
-    public void testNorm_fourD() {
-        // act/assert
-        Assert.assertEquals(0.0, Vectors.norm(0.0, 0.0, 0.0, 0.0), EPS);
-
-        Assert.assertEquals(Math.sqrt(30.0), Vectors.norm(1.0, 2.0, 3.0, 4.0), EPS);
-        Assert.assertEquals(Math.sqrt(174.0), Vectors.norm(5.0, 6.0, 7.0, -8.0), EPS);
-        Assert.assertEquals(Math.sqrt(446.0), Vectors.norm(9.0, 10.0, -11.0, 12.0), EPS);
-        Assert.assertEquals(Math.sqrt(846.0), Vectors.norm(13.0, -14.0, 15.0, 16.0), EPS);
-        Assert.assertEquals(Math.sqrt(1374.0), Vectors.norm(-17.0, 18.0, 19.0, 20.0), EPS);
-    }
-
-    @Test
     public void testNormSq_oneD() {
         // act/assert
         Assert.assertEquals(0.0, Vectors.normSq(0.0), EPS);
@@ -171,17 +158,5 @@ public class VectorsTest {
         Assert.assertEquals(869.0, Vectors.normSq(-16.0, 17.0, -18.0), EPS);
         Assert.assertEquals(1202.0, Vectors.normSq(-19.0, -20.0, 21.0), EPS);
         Assert.assertEquals(1589.0, Vectors.normSq(-22.0, -23.0, -24.0), EPS);
-    }
-
-    @Test
-    public void testNormSq_fourD() {
-        // act/assert
-        Assert.assertEquals(0.0, Vectors.normSq(0.0, 0.0, 0.0, 0.0), EPS);
-
-        Assert.assertEquals(30.0, Vectors.normSq(1.0, 2.0, 3.0, 4.0), EPS);
-        Assert.assertEquals(174.0, Vectors.normSq(5.0, 6.0, 7.0, -8.0), EPS);
-        Assert.assertEquals(446.0, Vectors.normSq(9.0, 10.0, -11.0, 12.0), EPS);
-        Assert.assertEquals(846.0, Vectors.normSq(13.0, -14.0, 15.0, 16.0), EPS);
-        Assert.assertEquals(1374.0, Vectors.normSq(-17.0, 18.0, 19.0, 20.0), EPS);
     }
 }

--- a/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/oned/AffineTransformMatrix1DTest.java
+++ b/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/oned/AffineTransformMatrix1DTest.java
@@ -427,7 +427,7 @@ public class AffineTransformMatrix1DTest {
 
             Vector1D expectedVec = vec
                     .add(translation1)
-                    .scalarMultiply(scale)
+                    .multiply(scale)
                     .add(translation2);
 
             EuclideanTestUtils.assertCoordinatesEqual(expectedVec, transform.apply(vec), EPS);
@@ -469,7 +469,7 @@ public class AffineTransformMatrix1DTest {
 
             Vector1D expectedVec = vec
                     .add(translation1)
-                    .scalarMultiply(scale)
+                    .multiply(scale)
                     .add(translation2);
 
             EuclideanTestUtils.assertCoordinatesEqual(expectedVec, transform.apply(vec), EPS);
@@ -477,9 +477,9 @@ public class AffineTransformMatrix1DTest {
     }
 
     @Test
-    public void testGetInverse_identity() {
+    public void testInverse_identity() {
         // act
-        AffineTransformMatrix1D inverse = AffineTransformMatrix1D.identity().getInverse();
+        AffineTransformMatrix1D inverse = AffineTransformMatrix1D.identity().inverse();
 
         // assert
         double[] expected = { 1, 0 };
@@ -487,11 +487,11 @@ public class AffineTransformMatrix1DTest {
     }
 
     @Test
-    public void testGetInverse_multiplyByInverse_producesIdentity() {
+    public void testInverse_multiplyByInverse_producesIdentity() {
         // arrange
         AffineTransformMatrix1D a = AffineTransformMatrix1D.of(1, 3);
 
-        AffineTransformMatrix1D inv = a.getInverse();
+        AffineTransformMatrix1D inv = a.inverse();
 
         // act
         AffineTransformMatrix1D result = inv.multiply(a);
@@ -502,12 +502,12 @@ public class AffineTransformMatrix1DTest {
     }
 
     @Test
-    public void testGetInverse_translate() {
+    public void testInverse_translate() {
         // arrange
         AffineTransformMatrix1D transform = AffineTransformMatrix1D.createTranslation(3);
 
         // act
-        AffineTransformMatrix1D inverse = transform.getInverse();
+        AffineTransformMatrix1D inverse = transform.inverse();
 
         // assert
         double[] expected = { 1, -3 };
@@ -515,12 +515,12 @@ public class AffineTransformMatrix1DTest {
     }
 
     @Test
-    public void testGetInverse_scale() {
+    public void testInverse_scale() {
         // arrange
         AffineTransformMatrix1D transform = AffineTransformMatrix1D.createScale(10);
 
         // act
-        AffineTransformMatrix1D inverse = transform.getInverse();
+        AffineTransformMatrix1D inverse = transform.inverse();
 
         // assert
         double[] expected = { 0.1, 0 };
@@ -528,7 +528,7 @@ public class AffineTransformMatrix1DTest {
     }
 
     @Test
-    public void testGetInverse_undoesOriginalTransform_translationAndScale() {
+    public void testInverse_undoesOriginalTransform_translationAndScale() {
         // arrange
         Vector1D v1 = Vector1D.ZERO;
         Vector1D v2 = Vector1D.ONE;
@@ -542,7 +542,7 @@ public class AffineTransformMatrix1DTest {
                         .scale(2)
                         .translate(x / 3);
 
-            AffineTransformMatrix1D inverse = transform.getInverse();
+            AffineTransformMatrix1D inverse = transform.inverse();
 
             EuclideanTestUtils.assertCoordinatesEqual(v1, inverse.apply(transform.apply(v1)), EPS);
             EuclideanTestUtils.assertCoordinatesEqual(v2, inverse.apply(transform.apply(v2)), EPS);
@@ -552,34 +552,34 @@ public class AffineTransformMatrix1DTest {
     }
 
     @Test
-    public void testGetInverse_nonInvertible() {
+    public void testInverse_nonInvertible() {
         // act/assert
         GeometryTestUtils.assertThrows(() -> {
-            AffineTransformMatrix1D.of(0, 0).getInverse();
+            AffineTransformMatrix1D.of(0, 0).inverse();
         }, NonInvertibleTransformException.class, "Transform is not invertible; matrix determinant is 0.0");
 
         GeometryTestUtils.assertThrows(() -> {
-            AffineTransformMatrix1D.of(Double.NaN, 0).getInverse();
+            AffineTransformMatrix1D.of(Double.NaN, 0).inverse();
         }, NonInvertibleTransformException.class, "Transform is not invertible; matrix determinant is NaN");
 
         GeometryTestUtils.assertThrows(() -> {
-            AffineTransformMatrix1D.of(Double.NEGATIVE_INFINITY, 0.0).getInverse();
+            AffineTransformMatrix1D.of(Double.NEGATIVE_INFINITY, 0.0).inverse();
         }, NonInvertibleTransformException.class, "Transform is not invertible; matrix determinant is -Infinity");
 
         GeometryTestUtils.assertThrows(() -> {
-            AffineTransformMatrix1D.of(Double.POSITIVE_INFINITY, 0).getInverse();
+            AffineTransformMatrix1D.of(Double.POSITIVE_INFINITY, 0).inverse();
         }, NonInvertibleTransformException.class, "Transform is not invertible; matrix determinant is Infinity");
 
         GeometryTestUtils.assertThrows(() -> {
-            AffineTransformMatrix1D.of(1, Double.NaN).getInverse();
+            AffineTransformMatrix1D.of(1, Double.NaN).inverse();
         }, NonInvertibleTransformException.class, "Transform is not invertible; invalid matrix element: NaN");
 
         GeometryTestUtils.assertThrows(() -> {
-            AffineTransformMatrix1D.of(1, Double.NEGATIVE_INFINITY).getInverse();
+            AffineTransformMatrix1D.of(1, Double.NEGATIVE_INFINITY).inverse();
         }, NonInvertibleTransformException.class, "Transform is not invertible; invalid matrix element: -Infinity");
 
         GeometryTestUtils.assertThrows(() -> {
-            AffineTransformMatrix1D.of(1, Double.POSITIVE_INFINITY).getInverse();
+            AffineTransformMatrix1D.of(1, Double.POSITIVE_INFINITY).inverse();
         }, NonInvertibleTransformException.class, "Transform is not invertible; invalid matrix element: Infinity");
     }
 

--- a/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/oned/Vector1DTest.java
+++ b/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/oned/Vector1DTest.java
@@ -305,11 +305,11 @@ public class Vector1DTest {
         Vector1D v3 = Vector1D.of(3);
 
         // act/assert
-        Assert.assertEquals(-6.0, v1.dotProduct(v2), TEST_TOLERANCE);
-        Assert.assertEquals(-6.0, v2.dotProduct(v1), TEST_TOLERANCE);
+        Assert.assertEquals(-6.0, v1.dot(v2), TEST_TOLERANCE);
+        Assert.assertEquals(-6.0, v2.dot(v1), TEST_TOLERANCE);
 
-        Assert.assertEquals(6.0, v1.dotProduct(v3), TEST_TOLERANCE);
-        Assert.assertEquals(6.0, v3.dotProduct(v1), TEST_TOLERANCE);
+        Assert.assertEquals(6.0, v1.dot(v3), TEST_TOLERANCE);
+        Assert.assertEquals(6.0, v3.dot(v1), TEST_TOLERANCE);
     }
 
     @Test

--- a/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/oned/Vector1DTest.java
+++ b/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/oned/Vector1DTest.java
@@ -105,17 +105,17 @@ public class Vector1DTest {
     @Test
     public void testNorm() {
         // act/assert
-        Assert.assertEquals(0.0, Vector1D.ZERO.getNorm(), TEST_TOLERANCE);
-        Assert.assertEquals(3.0, Vector1D.of(3).getNorm(), TEST_TOLERANCE);
-        Assert.assertEquals(3.0, Vector1D.of(-3).getNorm(), TEST_TOLERANCE);
+        Assert.assertEquals(0.0, Vector1D.ZERO.norm(), TEST_TOLERANCE);
+        Assert.assertEquals(3.0, Vector1D.of(3).norm(), TEST_TOLERANCE);
+        Assert.assertEquals(3.0, Vector1D.of(-3).norm(), TEST_TOLERANCE);
     }
 
     @Test
     public void testNormSq() {
         // act/assert
-        Assert.assertEquals(0.0, Vector1D.of(0).getNormSq(), TEST_TOLERANCE);
-        Assert.assertEquals(9.0, Vector1D.of(3).getNormSq(), TEST_TOLERANCE);
-        Assert.assertEquals(9.0, Vector1D.of(-3).getNormSq(), TEST_TOLERANCE);
+        Assert.assertEquals(0.0, Vector1D.of(0).normSq(), TEST_TOLERANCE);
+        Assert.assertEquals(9.0, Vector1D.of(3).normSq(), TEST_TOLERANCE);
+        Assert.assertEquals(9.0, Vector1D.of(-3).normSq(), TEST_TOLERANCE);
     }
 
     @Test
@@ -154,7 +154,7 @@ public class Vector1DTest {
 
         for (double mag = -10.0; mag <= 10.0; ++mag)
         {
-            Assert.assertEquals(Math.abs(mag), v.withNorm(mag).getNorm(), TEST_TOLERANCE);
+            Assert.assertEquals(Math.abs(mag), v.withNorm(mag).norm(), TEST_TOLERANCE);
         }
     }
 
@@ -262,11 +262,11 @@ public class Vector1DTest {
     @Test
     public void testScalarMultiply() {
         // act/assert
-        checkVector(Vector1D.of(1).scalarMultiply(3), 3);
-        checkVector(Vector1D.of(1).scalarMultiply(-3), -3);
+        checkVector(Vector1D.of(1).multiply(3), 3);
+        checkVector(Vector1D.of(1).multiply(-3), -3);
 
-        checkVector(Vector1D.of(1.5).scalarMultiply(7), 10.5);
-        checkVector(Vector1D.of(-1.5).scalarMultiply(7), -10.5);
+        checkVector(Vector1D.of(1.5).multiply(7), 10.5);
+        checkVector(Vector1D.of(-1.5).multiply(7), -10.5);
     }
 
     @Test
@@ -280,7 +280,7 @@ public class Vector1DTest {
 
         Assert.assertEquals(5.0, v1.distance(v2), TEST_TOLERANCE);
         Assert.assertEquals(5.0, v2.distance(v1), TEST_TOLERANCE);
-        Assert.assertEquals(v1.subtract(v2).getNorm(), v1.distance(v2), TEST_TOLERANCE);
+        Assert.assertEquals(v1.subtract(v2).norm(), v1.distance(v2), TEST_TOLERANCE);
 
         Assert.assertEquals(0.0, Vector1D.of(-1).distance(Vector1D.of(-1)), TEST_TOLERANCE);
     }

--- a/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/threed/AffineTransformMatrix3DTest.java
+++ b/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/threed/AffineTransformMatrix3DTest.java
@@ -443,7 +443,7 @@ public class AffineTransformMatrix3DTest {
         runWithCoordinates((x, y, z) -> {
             Vector3D vec = Vector3D.of(x, y, z);
 
-            Vector3D expectedVec = StandardRotations.PLUS_Z_HALF_PI.apply(vec.scalarMultiply(scaleFactor).subtract(center)).add(center);
+            Vector3D expectedVec = StandardRotations.PLUS_Z_HALF_PI.apply(vec.multiply(scaleFactor).subtract(center)).add(center);
 
             EuclideanTestUtils.assertCoordinatesEqual(expectedVec, transform.apply(vec), EPS);
         });
@@ -641,7 +641,7 @@ public class AffineTransformMatrix3DTest {
 
             Vector3D expectedVec = vec
                     .add(translation1)
-                    .scalarMultiply(scale)
+                    .multiply(scale)
                     .add(translation2);
 
             EuclideanTestUtils.assertCoordinatesEqual(expectedVec, transform.apply(vec), EPS);
@@ -695,7 +695,7 @@ public class AffineTransformMatrix3DTest {
 
             Vector3D expectedVec = vec
                     .add(translation1)
-                    .scalarMultiply(scale)
+                    .multiply(scale)
                     .add(translation2);
 
             EuclideanTestUtils.assertCoordinatesEqual(expectedVec, transform.apply(vec), EPS);
@@ -703,9 +703,9 @@ public class AffineTransformMatrix3DTest {
     }
 
     @Test
-    public void testGetInverse_identity() {
+    public void testInverse_identity() {
         // act
-        AffineTransformMatrix3D inverse = AffineTransformMatrix3D.identity().getInverse();
+        AffineTransformMatrix3D inverse = AffineTransformMatrix3D.identity().inverse();
 
         // assert
         double[] expected = {
@@ -717,7 +717,7 @@ public class AffineTransformMatrix3DTest {
     }
 
     @Test
-    public void testGetInverse_multiplyByInverse_producesIdentity() {
+    public void testInverse_multiplyByInverse_producesIdentity() {
         // arrange
         AffineTransformMatrix3D a = AffineTransformMatrix3D.of(
                     1, 3, 7, 8,
@@ -725,7 +725,7 @@ public class AffineTransformMatrix3DTest {
                     5, 6, 10, 11
                 );
 
-        AffineTransformMatrix3D inv = a.getInverse();
+        AffineTransformMatrix3D inv = a.inverse();
 
         // act
         AffineTransformMatrix3D result = inv.multiply(a);
@@ -740,12 +740,12 @@ public class AffineTransformMatrix3DTest {
     }
 
     @Test
-    public void testGetInverse_translate() {
+    public void testInverse_translate() {
         // arrange
         AffineTransformMatrix3D transform = AffineTransformMatrix3D.createTranslation(1, -2, 4);
 
         // act
-        AffineTransformMatrix3D inverse = transform.getInverse();
+        AffineTransformMatrix3D inverse = transform.inverse();
 
         // assert
         double[] expected = {
@@ -757,12 +757,12 @@ public class AffineTransformMatrix3DTest {
     }
 
     @Test
-    public void testGetInverse_scale() {
+    public void testInverse_scale() {
         // arrange
         AffineTransformMatrix3D transform = AffineTransformMatrix3D.createScale(10, -2, 4);
 
         // act
-        AffineTransformMatrix3D inverse = transform.getInverse();
+        AffineTransformMatrix3D inverse = transform.inverse();
 
         // assert
         double[] expected = {
@@ -774,7 +774,7 @@ public class AffineTransformMatrix3DTest {
     }
 
     @Test
-    public void testGetInverse_rotate() {
+    public void testInverse_rotate() {
         // arrange
         Vector3D center = Vector3D.of(1, 2, 3);
         QuaternionRotation rotation = QuaternionRotation.fromAxisAngle(Vector3D.PLUS_Z, Geometry.HALF_PI);
@@ -782,7 +782,7 @@ public class AffineTransformMatrix3DTest {
         AffineTransformMatrix3D transform = AffineTransformMatrix3D.createRotation(center, rotation);
 
         // act
-        AffineTransformMatrix3D inverse = transform.getInverse();
+        AffineTransformMatrix3D inverse = transform.inverse();
 
         // assert
         double[] expected = {
@@ -794,7 +794,7 @@ public class AffineTransformMatrix3DTest {
     }
 
     @Test
-    public void testGetInverse_undoesOriginalTransform() {
+    public void testInverse_undoesOriginalTransform() {
         // arrange
         Vector3D v1 = Vector3D.ZERO;
         Vector3D v2 = Vector3D.PLUS_X;
@@ -812,7 +812,7 @@ public class AffineTransformMatrix3DTest {
                         .rotate(center, rotation)
                         .translate(x / 3, y / 3, z / 3);
 
-            AffineTransformMatrix3D inverse = transform.getInverse();
+            AffineTransformMatrix3D inverse = transform.inverse();
 
             EuclideanTestUtils.assertCoordinatesEqual(v1, inverse.apply(transform.apply(v1)), EPS);
             EuclideanTestUtils.assertCoordinatesEqual(v2, inverse.apply(transform.apply(v2)), EPS);
@@ -822,55 +822,55 @@ public class AffineTransformMatrix3DTest {
     }
 
     @Test
-    public void testGetInverse_nonInvertible() {
+    public void testInverse_nonInvertible() {
         // act/assert
         GeometryTestUtils.assertThrows(() -> {
             AffineTransformMatrix3D.of(
                     0, 0, 0, 0,
                     0, 0, 0, 0,
-                    0, 0, 0, 0).getInverse();
+                    0, 0, 0, 0).inverse();
         }, NonInvertibleTransformException.class, "Transform is not invertible; matrix determinant is 0.0");
 
         GeometryTestUtils.assertThrows(() -> {
             AffineTransformMatrix3D.of(
                     1, 0, 0, 0,
                     0, 1, 0, 0,
-                    0, 0, Double.NaN, 0).getInverse();
+                    0, 0, Double.NaN, 0).inverse();
         }, NonInvertibleTransformException.class, "Transform is not invertible; matrix determinant is NaN");
 
         GeometryTestUtils.assertThrows(() -> {
             AffineTransformMatrix3D.of(
                     1, 0, 0, 0,
                     0, Double.NEGATIVE_INFINITY, 0, 0,
-                    0, 0, 1, 0).getInverse();
+                    0, 0, 1, 0).inverse();
         }, NonInvertibleTransformException.class, "Transform is not invertible; matrix determinant is NaN");
 
         GeometryTestUtils.assertThrows(() -> {
             AffineTransformMatrix3D.of(
                     Double.POSITIVE_INFINITY, 0, 0, 0,
                     0, 1, 0, 0,
-                    0, 0, 1, 0).getInverse();
+                    0, 0, 1, 0).inverse();
         }, NonInvertibleTransformException.class, "Transform is not invertible; matrix determinant is NaN");
 
         GeometryTestUtils.assertThrows(() -> {
             AffineTransformMatrix3D.of(
                     1, 0, 0, Double.NaN,
                     0, 1, 0, 0,
-                    0, 0, 1, 0).getInverse();
+                    0, 0, 1, 0).inverse();
         }, NonInvertibleTransformException.class, "Transform is not invertible; invalid matrix element: NaN");
 
         GeometryTestUtils.assertThrows(() -> {
             AffineTransformMatrix3D.of(
                     1, 0, 0, 0,
                     0, 1, 0, Double.POSITIVE_INFINITY,
-                    0, 0, 1, 0).getInverse();
+                    0, 0, 1, 0).inverse();
         }, NonInvertibleTransformException.class, "Transform is not invertible; invalid matrix element: Infinity");
 
         GeometryTestUtils.assertThrows(() -> {
             AffineTransformMatrix3D.of(
                     1, 0, 0, 0,
                     0, 1, 0, 0,
-                    0, 0, 1, Double.NEGATIVE_INFINITY).getInverse();
+                    0, 0, 1, Double.NEGATIVE_INFINITY).inverse();
         }, NonInvertibleTransformException.class, "Transform is not invertible; invalid matrix element: -Infinity");
     }
 

--- a/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/threed/LineTest.java
+++ b/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/threed/LineTest.java
@@ -28,7 +28,7 @@ public class LineTest {
         Assert.assertTrue(l.contains(p1));
         Assert.assertTrue(l.contains(Vector3D.linearCombination(1.0, p1, 0.3, l.getDirection())));
         Vector3D u = l.getDirection().orthogonal();
-        Vector3D v = l.getDirection().crossProduct(u);
+        Vector3D v = l.getDirection().cross(u);
         for (double alpha = 0; alpha < 2 * Math.PI; alpha += 0.3) {
             Assert.assertTrue(! l.contains(p1.add(Vector3D.linearCombination(Math.cos(alpha), u,
                                                                Math.sin(alpha), v))));

--- a/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/threed/PolyhedronsSetTest.java
+++ b/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/threed/PolyhedronsSetTest.java
@@ -910,7 +910,7 @@ public class PolyhedronsSetTest {
             SubHyperplane<Vector3D> plane = polyset.firstIntersection(origin, line);
             if (plane != null) {
                 Vector3D intersectionPoint = ((Plane)plane.getHyperplane()).intersection(line);
-                double dotProduct = direction.dotProduct(intersectionPoint.subtract(origin));
+                double dotProduct = direction.dot(intersectionPoint.subtract(origin));
                 Assert.assertTrue(dotProduct > 0);
             }
         }

--- a/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/threed/PolyhedronsSetTest.java
+++ b/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/threed/PolyhedronsSetTest.java
@@ -553,7 +553,7 @@ public class PolyhedronsSetTest {
                          1.0, c,
                          1.0, r.apply(barycenter.subtract(c)));
         Assert.assertEquals(0.0,
-                            newB.subtract(tree.getBarycenter()).getNorm(),
+                            newB.subtract(tree.getBarycenter()).norm(),
                             TEST_TOLERANCE);
 
         final Vector3D[] expectedV = new Vector3D[] {
@@ -603,7 +603,7 @@ public class PolyhedronsSetTest {
                     Vector3D v = plane.toSpace(vertices[0][i]);
                     double d = Double.POSITIVE_INFINITY;
                     for (int k = 0; k < expectedV.length; ++k) {
-                        d = Math.min(d, v.subtract(expectedV[k]).getNorm());
+                        d = Math.min(d, v.subtract(expectedV[k]).norm());
                     }
                     Assert.assertEquals(0, d, TEST_TOLERANCE);
                 }
@@ -1459,7 +1459,7 @@ public class PolyhedronsSetTest {
                 y = Math.sin(hAngle) * stackRadius;
 
                 norm = Vector3D.of(x, y, stackHeight).normalize();
-                pt = center.add(norm.scalarMultiply(adjustedRadius));
+                pt = center.add(norm.multiply(adjustedRadius));
 
                 planes.add(new Plane(pt, norm, TEST_TOLERANCE));
             }

--- a/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/threed/Vector3DTest.java
+++ b/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/threed/Vector3DTest.java
@@ -147,23 +147,23 @@ public class Vector3DTest {
 
         // assert
         checkVector(zero, 0, 0, 0);
-        Assert.assertEquals(0, zero.getNorm(), EPS);
+        Assert.assertEquals(0, zero.norm(), EPS);
     }
 
     @Test
     public void testNorm() {
         // act/assert
-        Assert.assertEquals(0.0, Vector3D.ZERO.getNorm(), 0);
-        Assert.assertEquals(Math.sqrt(29), Vector3D.of(2, 3, 4).getNorm(), EPS);
-        Assert.assertEquals(Math.sqrt(29), Vector3D.of(-2, -3, -4).getNorm(), EPS);
+        Assert.assertEquals(0.0, Vector3D.ZERO.norm(), 0);
+        Assert.assertEquals(Math.sqrt(29), Vector3D.of(2, 3, 4).norm(), EPS);
+        Assert.assertEquals(Math.sqrt(29), Vector3D.of(-2, -3, -4).norm(), EPS);
     }
 
     @Test
     public void testNormSq() {
         // act/assert
-        Assert.assertEquals(0.0, Vector3D.ZERO.getNormSq(), 0);
-        Assert.assertEquals(29, Vector3D.of(2, 3, 4).getNormSq(), EPS);
-        Assert.assertEquals(29, Vector3D.of(-2, -3, -4).getNormSq(), EPS);
+        Assert.assertEquals(0.0, Vector3D.ZERO.normSq(), 0);
+        Assert.assertEquals(29, Vector3D.of(2, 3, 4).normSq(), EPS);
+        Assert.assertEquals(29, Vector3D.of(-2, -3, -4).normSq(), EPS);
     }
 
     @Test
@@ -199,7 +199,7 @@ public class Vector3DTest {
 
         for (double mag = -10.0; mag <= 10.0; ++mag)
         {
-            Assert.assertEquals(Math.abs(mag), Vector3D.of(x, y, z).withNorm(mag).getNorm(), EPS);
+            Assert.assertEquals(Math.abs(mag), Vector3D.of(x, y, z).withNorm(mag).norm(), EPS);
         }
     }
 
@@ -228,7 +228,7 @@ public class Vector3DTest {
 
         for (double mag = -10.0; mag <= 10.0; ++mag)
         {
-            Assert.assertEquals(Math.abs(mag), v.withNorm(mag).getNorm(), EPS);
+            Assert.assertEquals(Math.abs(mag), v.withNorm(mag).norm(), EPS);
         }
     }
 
@@ -329,7 +329,7 @@ public class Vector3DTest {
         checkVector(Vector3D.of(2, 2, 2).normalize(), invSqrt3, invSqrt3, invSqrt3);
         checkVector(Vector3D.of(-2, -2, -2).normalize(), -invSqrt3, -invSqrt3, -invSqrt3);
 
-        Assert.assertEquals(1.0, Vector3D.of(5, -4, 2).normalize().getNorm(), EPS);
+        Assert.assertEquals(1.0, Vector3D.of(5, -4, 2).normalize().norm(), EPS);
     }
 
     @Test
@@ -486,7 +486,7 @@ public class Vector3DTest {
 
         Vector3D  k = v1.normalize();
         Vector3D  i = k.orthogonal();
-        Vector3D v2 = k.scalarMultiply(Math.cos(1.2)).add(i.scalarMultiply(Math.sin(1.2)));
+        Vector3D v2 = k.multiply(Math.cos(1.2)).add(i.multiply(Math.sin(1.2)));
 
         // act/assert
         Assert.assertTrue(Math.abs(v1.angle(v2) - 1.2) < 1.0e-12);
@@ -533,8 +533,8 @@ public class Vector3DTest {
         Vector3D cAccurate = u1.crossProduct(u2);
 
         // assert
-        Assert.assertTrue(u3.distance(cNaive) > 2.9 * u3.getNorm());
-        Assert.assertEquals(0.0, u3.distance(cAccurate), 1.0e-30 * cAccurate.getNorm());
+        Assert.assertTrue(u3.distance(cNaive) > 2.9 * u3.norm());
+        Assert.assertEquals(0.0, u3.distance(cAccurate), 1.0e-30 * cAccurate.norm());
     }
 
     @Test
@@ -556,7 +556,7 @@ public class Vector3DTest {
             Vector3D cAccurate = Vector3D.of(ux, uy, uz).crossProduct(Vector3D.of(vx, vy, vz));
 
             // assert
-            Assert.assertEquals(0.0, cAccurate.distance(cNaive), 6.0e-15 * cAccurate.getNorm());
+            Assert.assertEquals(0.0, cAccurate.distance(cNaive), 6.0e-15 * cAccurate.norm());
         }
     }
 
@@ -580,17 +580,17 @@ public class Vector3DTest {
         Vector3D v2 = Vector3D.of(-2, -3, -4);
 
         // act/assert
-        checkVector(v1.scalarMultiply(0), 0, 0, 0);
-        checkVector(v1.scalarMultiply(0.5), 1, 1.5, 2);
-        checkVector(v1.scalarMultiply(1), 2, 3, 4);
-        checkVector(v1.scalarMultiply(2), 4, 6, 8);
-        checkVector(v1.scalarMultiply(-2), -4, -6, -8);
+        checkVector(v1.multiply(0), 0, 0, 0);
+        checkVector(v1.multiply(0.5), 1, 1.5, 2);
+        checkVector(v1.multiply(1), 2, 3, 4);
+        checkVector(v1.multiply(2), 4, 6, 8);
+        checkVector(v1.multiply(-2), -4, -6, -8);
 
-        checkVector(v2.scalarMultiply(0), 0, 0, 0);
-        checkVector(v2.scalarMultiply(0.5), -1, -1.5, -2);
-        checkVector(v2.scalarMultiply(1), -2, -3, -4);
-        checkVector(v2.scalarMultiply(2), -4, -6, -8);
-        checkVector(v2.scalarMultiply(-2), 4, 6, 8);
+        checkVector(v2.multiply(0), 0, 0, 0);
+        checkVector(v2.multiply(0.5), -1, -1.5, -2);
+        checkVector(v2.multiply(1), -2, -3, -4);
+        checkVector(v2.multiply(2), -4, -6, -8);
+        checkVector(v2.multiply(-2), 4, 6, 8);
     }
 
     @Test
@@ -607,7 +607,7 @@ public class Vector3DTest {
         Assert.assertEquals(Math.sqrt(50), v1.distance(v2), EPS);
         Assert.assertEquals(Math.sqrt(50), v2.distance(v1), EPS);
 
-        Assert.assertEquals(v1.subtract(v2).getNorm(), v1.distance(v2), EPS);
+        Assert.assertEquals(v1.subtract(v2).norm(), v1.distance(v2), EPS);
 
         Assert.assertEquals(Math.sqrt(132), v1.distance(v3), EPS);
         Assert.assertEquals(Math.sqrt(132), v3.distance(v1), EPS);
@@ -627,7 +627,7 @@ public class Vector3DTest {
         Assert.assertEquals(50, v1.distanceSq(v2), EPS);
         Assert.assertEquals(50, v2.distanceSq(v1), EPS);
 
-        Assert.assertEquals(v1.subtract(v2).getNormSq(), v1.distanceSq(v2), EPS);
+        Assert.assertEquals(v1.subtract(v2).normSq(), v1.distanceSq(v2), EPS);
 
         Assert.assertEquals(132, v1.distanceSq(v3), EPS);
         Assert.assertEquals(132, v3.distanceSq(v1), EPS);

--- a/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/threed/Vector3DTest.java
+++ b/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/threed/Vector3DTest.java
@@ -365,10 +365,10 @@ public class Vector3DTest {
         Vector3D v4 = Vector3D.of(4.2, 0.1, -1.8);
 
         // act/assert
-        Assert.assertEquals(0.0, v1.dotProduct(v1.orthogonal()), EPS);
-        Assert.assertEquals(0.0, v2.dotProduct(v2.orthogonal()), EPS);
-        Assert.assertEquals(0.0, v3.dotProduct(v3.orthogonal()), EPS);
-        Assert.assertEquals(0.0, v4.dotProduct(v4.orthogonal()), EPS);
+        Assert.assertEquals(0.0, v1.dot(v1.orthogonal()), EPS);
+        Assert.assertEquals(0.0, v2.dot(v2.orthogonal()), EPS);
+        Assert.assertEquals(0.0, v3.dot(v3.orthogonal()), EPS);
+        Assert.assertEquals(0.0, v4.dot(v4.orthogonal()), EPS);
     }
 
     @Test
@@ -495,16 +495,16 @@ public class Vector3DTest {
     @Test
     public void testCrossProduct() {
         // act/assert
-        checkVector(Vector3D.PLUS_X.crossProduct(Vector3D.PLUS_Y), 0, 0, 1);
-        checkVector(Vector3D.PLUS_X.crossProduct(Vector3D.MINUS_Y), 0, 0, -1);
+        checkVector(Vector3D.PLUS_X.cross(Vector3D.PLUS_Y), 0, 0, 1);
+        checkVector(Vector3D.PLUS_X.cross(Vector3D.MINUS_Y), 0, 0, -1);
 
-        checkVector(Vector3D.MINUS_X.crossProduct(Vector3D.MINUS_Y), 0, 0, 1);
-        checkVector(Vector3D.MINUS_X.crossProduct(Vector3D.PLUS_Y), 0, 0, -1);
+        checkVector(Vector3D.MINUS_X.cross(Vector3D.MINUS_Y), 0, 0, 1);
+        checkVector(Vector3D.MINUS_X.cross(Vector3D.PLUS_Y), 0, 0, -1);
 
-        checkVector(Vector3D.of(2, 1, -4).crossProduct(Vector3D.of(3, 1, -1)), 3, -10, -1);
+        checkVector(Vector3D.of(2, 1, -4).cross(Vector3D.of(3, 1, -1)), 3, -10, -1);
 
         double invSqrt6 = 1 / Math.sqrt(6);
-        checkVector(Vector3D.of(1, 1, 1).crossProduct(Vector3D.of(-1, 0, 1)).normalize(), invSqrt6, - 2 * invSqrt6, invSqrt6);
+        checkVector(Vector3D.of(1, 1, 1).cross(Vector3D.of(-1, 0, 1)).normalize(), invSqrt6, - 2 * invSqrt6, invSqrt6);
     }
 
     @Test
@@ -530,7 +530,7 @@ public class Vector3DTest {
         Vector3D cNaive = Vector3D.of(u1.getY() * u2.getZ() - u1.getZ() * u2.getY(),
                                        u1.getZ() * u2.getX() - u1.getX() * u2.getZ(),
                                        u1.getX() * u2.getY() - u1.getY() * u2.getX());
-        Vector3D cAccurate = u1.crossProduct(u2);
+        Vector3D cAccurate = u1.cross(u2);
 
         // assert
         Assert.assertTrue(u3.distance(cNaive) > 2.9 * u3.norm());
@@ -553,7 +553,7 @@ public class Vector3DTest {
 
             // act
             Vector3D cNaive = Vector3D.of(uy * vz - uz * vy, uz * vx - ux * vz, ux * vy - uy * vx);
-            Vector3D cAccurate = Vector3D.of(ux, uy, uz).crossProduct(Vector3D.of(vx, vy, vz));
+            Vector3D cAccurate = Vector3D.of(ux, uy, uz).cross(Vector3D.of(vx, vy, vz));
 
             // assert
             Assert.assertEquals(0.0, cAccurate.distance(cNaive), 6.0e-15 * cAccurate.norm());
@@ -565,12 +565,12 @@ public class Vector3DTest {
         // act/assert
         Vector3D v1 = Vector3D.of(9070467121.0, 4535233560.0, 1);
         Vector3D v2 = Vector3D.of(9070467123.0, 4535233561.0, 1);
-        checkVector(v1.crossProduct(v2), -1, 2, 1);
+        checkVector(v1.cross(v2), -1, 2, 1);
 
         double scale    = Math.scalb(1.0, 100);
         Vector3D big1   = Vector3D.linearCombination(scale, v1);
         Vector3D small2 = Vector3D.linearCombination(1 / scale, v2);
-        checkVector(big1.crossProduct(small2), -1, 2, 1);
+        checkVector(big1.cross(small2), -1, 2, 1);
     }
 
     @Test
@@ -641,13 +641,13 @@ public class Vector3DTest {
         Vector3D v3 = Vector3D.of(7, 8, 9);
 
         // act/assert
-        Assert.assertEquals(14, v1.dotProduct(v1), EPS);
+        Assert.assertEquals(14, v1.dot(v1), EPS);
 
-        Assert.assertEquals(-32, v1.dotProduct(v2), EPS);
-        Assert.assertEquals(-32, v2.dotProduct(v1), EPS);
+        Assert.assertEquals(-32, v1.dot(v2), EPS);
+        Assert.assertEquals(-32, v2.dot(v1), EPS);
 
-        Assert.assertEquals(18, v1.dotProduct(v3), EPS);
-        Assert.assertEquals(18, v3.dotProduct(v1), EPS);
+        Assert.assertEquals(18, v1.dot(v3), EPS);
+        Assert.assertEquals(18, v3.dot(v1), EPS);
     }
 
     @Test
@@ -666,7 +666,7 @@ public class Vector3DTest {
 
         // act
         double sNaive = u1.getX() * u2.getX() + u1.getY() * u2.getY() + u1.getZ() * u2.getZ();
-        double sAccurate = u1.dotProduct(u2);
+        double sAccurate = u1.dot(u2);
 
         // assert
         Assert.assertEquals(0.0, sNaive, 1.0e-30);
@@ -689,7 +689,7 @@ public class Vector3DTest {
 
             // act
             double sNaive = ux * vx + uy * vy + uz * vz;
-            double sAccurate = Vector3D.of(ux, uy, uz).dotProduct(Vector3D.of(vx, vy, vz));
+            double sAccurate = Vector3D.of(ux, uy, uz).dot(Vector3D.of(vx, vy, vz));
 
             // assert
             Assert.assertEquals(sNaive, sAccurate, 2.5e-16 * sAccurate);

--- a/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/threed/rotation/QuaternionRotationTest.java
+++ b/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/threed/rotation/QuaternionRotationTest.java
@@ -197,7 +197,7 @@ public class QuaternionRotationTest {
             Assert.assertTrue(angle <= Geometry.PI);
 
             double expected = PlaneAngleRadians.normalizeBetweenMinusPiAndPi(theta);
-            if (PLUS_DIAGONAL.dotProduct(rot.getAxis()) < 0) {
+            if (PLUS_DIAGONAL.dot(rot.getAxis()) < 0) {
                 // if the axis ended up being flipped, then negate the expected angle
                 expected *= -1;
             }
@@ -1116,8 +1116,8 @@ public class QuaternionRotationTest {
 
         // assert
         Vector3D axis = q.getAxis();
-        Assert.assertEquals(0.0, axis.dotProduct(u1), EPS);
-        Assert.assertEquals(0.0, axis.dotProduct(u2), EPS);
+        Assert.assertEquals(0.0, axis.dot(u1), EPS);
+        Assert.assertEquals(0.0, axis.dot(u2), EPS);
         Assert.assertEquals(Geometry.PI, q.getAngle(), EPS);
 
         EuclideanTestUtils.assertCoordinatesEqual(Vector3D.of(0, -2, 0), q.apply(u1), EPS);
@@ -1320,12 +1320,12 @@ public class QuaternionRotationTest {
             Assert.assertEquals(1.0, transformedY.norm(), EPS);
             Assert.assertEquals(1.0, transformedZ.norm(), EPS);
 
-            Assert.assertEquals(0.0, transformedX.dotProduct(transformedY), EPS);
-            Assert.assertEquals(0.0, transformedX.dotProduct(transformedZ), EPS);
-            Assert.assertEquals(0.0, transformedY.dotProduct(transformedZ), EPS);
+            Assert.assertEquals(0.0, transformedX.dot(transformedY), EPS);
+            Assert.assertEquals(0.0, transformedX.dot(transformedZ), EPS);
+            Assert.assertEquals(0.0, transformedY.dot(transformedZ), EPS);
 
             EuclideanTestUtils.assertCoordinatesEqual(transformedZ.normalize(),
-                    transformedX.normalize().crossProduct(transformedY.normalize()), EPS);
+                    transformedX.normalize().cross(transformedY.normalize()), EPS);
 
             Assert.assertEquals(1.0, q.getQuaternion().norm(), EPS);
         });

--- a/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/threed/rotation/QuaternionRotationTest.java
+++ b/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/threed/rotation/QuaternionRotationTest.java
@@ -26,7 +26,6 @@ import org.apache.commons.geometry.core.GeometryTestUtils;
 import org.apache.commons.geometry.core.exception.IllegalNormException;
 import org.apache.commons.geometry.core.internal.SimpleTupleFormat;
 import org.apache.commons.geometry.euclidean.EuclideanTestUtils;
-import org.apache.commons.geometry.euclidean.internal.Vectors;
 import org.apache.commons.geometry.euclidean.threed.AffineTransformMatrix3D;
 import org.apache.commons.geometry.euclidean.threed.Vector3D;
 import org.apache.commons.numbers.angle.PlaneAngleRadians;

--- a/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/threed/rotation/QuaternionRotationTest.java
+++ b/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/threed/rotation/QuaternionRotationTest.java
@@ -275,12 +275,12 @@ public class QuaternionRotationTest {
     }
 
     @Test
-    public void testGetInverse() {
+    public void testInverse() {
         // arrange
         QuaternionRotation rot = QuaternionRotation.of(0.5, 0.5, 0.5, 0.5);
 
         // act
-        QuaternionRotation neg = rot.getInverse();
+        QuaternionRotation neg = rot.inverse();
 
         // assert
         Assert.assertEquals(-0.5, neg.getQuaternion().getX(), EPS);
@@ -290,61 +290,61 @@ public class QuaternionRotationTest {
     }
 
     @Test
-    public void testGetInverse_apply() {
+    public void testInverse_apply() {
         // act/assert
 
         // --- x axes
-        assertRotationEquals(StandardRotations.IDENTITY, QuaternionRotation.fromAxisAngle(PLUS_X_DIR, Geometry.ZERO_PI).getInverse());
+        assertRotationEquals(StandardRotations.IDENTITY, QuaternionRotation.fromAxisAngle(PLUS_X_DIR, Geometry.ZERO_PI).inverse());
 
-        assertRotationEquals(StandardRotations.PLUS_X_HALF_PI, QuaternionRotation.fromAxisAngle(PLUS_X_DIR, Geometry.MINUS_HALF_PI).getInverse());
-        assertRotationEquals(StandardRotations.PLUS_X_HALF_PI, QuaternionRotation.fromAxisAngle(MINUS_X_DIR, Geometry.HALF_PI).getInverse());
+        assertRotationEquals(StandardRotations.PLUS_X_HALF_PI, QuaternionRotation.fromAxisAngle(PLUS_X_DIR, Geometry.MINUS_HALF_PI).inverse());
+        assertRotationEquals(StandardRotations.PLUS_X_HALF_PI, QuaternionRotation.fromAxisAngle(MINUS_X_DIR, Geometry.HALF_PI).inverse());
 
-        assertRotationEquals(StandardRotations.MINUS_X_HALF_PI, QuaternionRotation.fromAxisAngle(MINUS_X_DIR, Geometry.MINUS_HALF_PI).getInverse());
-        assertRotationEquals(StandardRotations.MINUS_X_HALF_PI, QuaternionRotation.fromAxisAngle(PLUS_X_DIR, Geometry.HALF_PI).getInverse());
+        assertRotationEquals(StandardRotations.MINUS_X_HALF_PI, QuaternionRotation.fromAxisAngle(MINUS_X_DIR, Geometry.MINUS_HALF_PI).inverse());
+        assertRotationEquals(StandardRotations.MINUS_X_HALF_PI, QuaternionRotation.fromAxisAngle(PLUS_X_DIR, Geometry.HALF_PI).inverse());
 
-        assertRotationEquals(StandardRotations.X_PI, QuaternionRotation.fromAxisAngle(PLUS_X_DIR, Geometry.PI).getInverse());
-        assertRotationEquals(StandardRotations.X_PI, QuaternionRotation.fromAxisAngle(MINUS_X_DIR, Geometry.PI).getInverse());
+        assertRotationEquals(StandardRotations.X_PI, QuaternionRotation.fromAxisAngle(PLUS_X_DIR, Geometry.PI).inverse());
+        assertRotationEquals(StandardRotations.X_PI, QuaternionRotation.fromAxisAngle(MINUS_X_DIR, Geometry.PI).inverse());
 
         // --- y axes
-        assertRotationEquals(StandardRotations.IDENTITY, QuaternionRotation.fromAxisAngle(PLUS_Y_DIR, Geometry.ZERO_PI).getInverse());
+        assertRotationEquals(StandardRotations.IDENTITY, QuaternionRotation.fromAxisAngle(PLUS_Y_DIR, Geometry.ZERO_PI).inverse());
 
-        assertRotationEquals(StandardRotations.PLUS_Y_HALF_PI, QuaternionRotation.fromAxisAngle(PLUS_Y_DIR, Geometry.MINUS_HALF_PI).getInverse());
-        assertRotationEquals(StandardRotations.PLUS_Y_HALF_PI, QuaternionRotation.fromAxisAngle(MINUS_Y_DIR, Geometry.HALF_PI).getInverse());
+        assertRotationEquals(StandardRotations.PLUS_Y_HALF_PI, QuaternionRotation.fromAxisAngle(PLUS_Y_DIR, Geometry.MINUS_HALF_PI).inverse());
+        assertRotationEquals(StandardRotations.PLUS_Y_HALF_PI, QuaternionRotation.fromAxisAngle(MINUS_Y_DIR, Geometry.HALF_PI).inverse());
 
-        assertRotationEquals(StandardRotations.MINUS_Y_HALF_PI, QuaternionRotation.fromAxisAngle(MINUS_Y_DIR, Geometry.MINUS_HALF_PI).getInverse());
-        assertRotationEquals(StandardRotations.MINUS_Y_HALF_PI, QuaternionRotation.fromAxisAngle(PLUS_Y_DIR, Geometry.HALF_PI).getInverse());
+        assertRotationEquals(StandardRotations.MINUS_Y_HALF_PI, QuaternionRotation.fromAxisAngle(MINUS_Y_DIR, Geometry.MINUS_HALF_PI).inverse());
+        assertRotationEquals(StandardRotations.MINUS_Y_HALF_PI, QuaternionRotation.fromAxisAngle(PLUS_Y_DIR, Geometry.HALF_PI).inverse());
 
-        assertRotationEquals(StandardRotations.Y_PI, QuaternionRotation.fromAxisAngle(PLUS_Y_DIR, Geometry.PI).getInverse());
-        assertRotationEquals(StandardRotations.Y_PI, QuaternionRotation.fromAxisAngle(MINUS_Y_DIR, Geometry.PI).getInverse());
+        assertRotationEquals(StandardRotations.Y_PI, QuaternionRotation.fromAxisAngle(PLUS_Y_DIR, Geometry.PI).inverse());
+        assertRotationEquals(StandardRotations.Y_PI, QuaternionRotation.fromAxisAngle(MINUS_Y_DIR, Geometry.PI).inverse());
 
         // --- z axes
-        assertRotationEquals(StandardRotations.IDENTITY, QuaternionRotation.fromAxisAngle(PLUS_Z_DIR, Geometry.ZERO_PI).getInverse());
+        assertRotationEquals(StandardRotations.IDENTITY, QuaternionRotation.fromAxisAngle(PLUS_Z_DIR, Geometry.ZERO_PI).inverse());
 
-        assertRotationEquals(StandardRotations.PLUS_Z_HALF_PI, QuaternionRotation.fromAxisAngle(PLUS_Z_DIR, Geometry.MINUS_HALF_PI).getInverse());
-        assertRotationEquals(StandardRotations.PLUS_Z_HALF_PI, QuaternionRotation.fromAxisAngle(MINUS_Z_DIR, Geometry.HALF_PI).getInverse());
+        assertRotationEquals(StandardRotations.PLUS_Z_HALF_PI, QuaternionRotation.fromAxisAngle(PLUS_Z_DIR, Geometry.MINUS_HALF_PI).inverse());
+        assertRotationEquals(StandardRotations.PLUS_Z_HALF_PI, QuaternionRotation.fromAxisAngle(MINUS_Z_DIR, Geometry.HALF_PI).inverse());
 
-        assertRotationEquals(StandardRotations.MINUS_Z_HALF_PI, QuaternionRotation.fromAxisAngle(MINUS_Z_DIR, Geometry.MINUS_HALF_PI).getInverse());
-        assertRotationEquals(StandardRotations.MINUS_Z_HALF_PI, QuaternionRotation.fromAxisAngle(PLUS_Z_DIR, Geometry.HALF_PI).getInverse());
+        assertRotationEquals(StandardRotations.MINUS_Z_HALF_PI, QuaternionRotation.fromAxisAngle(MINUS_Z_DIR, Geometry.MINUS_HALF_PI).inverse());
+        assertRotationEquals(StandardRotations.MINUS_Z_HALF_PI, QuaternionRotation.fromAxisAngle(PLUS_Z_DIR, Geometry.HALF_PI).inverse());
 
-        assertRotationEquals(StandardRotations.Z_PI, QuaternionRotation.fromAxisAngle(PLUS_Z_DIR, Geometry.PI).getInverse());
-        assertRotationEquals(StandardRotations.Z_PI, QuaternionRotation.fromAxisAngle(MINUS_Z_DIR, Geometry.PI).getInverse());
+        assertRotationEquals(StandardRotations.Z_PI, QuaternionRotation.fromAxisAngle(PLUS_Z_DIR, Geometry.PI).inverse());
+        assertRotationEquals(StandardRotations.Z_PI, QuaternionRotation.fromAxisAngle(MINUS_Z_DIR, Geometry.PI).inverse());
 
         // --- diagonal
-        assertRotationEquals(StandardRotations.PLUS_DIAGONAL_TWO_THIRDS_PI, QuaternionRotation.fromAxisAngle(PLUS_DIAGONAL, MINUS_TWO_THIRDS_PI).getInverse());
-        assertRotationEquals(StandardRotations.PLUS_DIAGONAL_TWO_THIRDS_PI, QuaternionRotation.fromAxisAngle(MINUS_DIAGONAL, TWO_THIRDS_PI).getInverse());
+        assertRotationEquals(StandardRotations.PLUS_DIAGONAL_TWO_THIRDS_PI, QuaternionRotation.fromAxisAngle(PLUS_DIAGONAL, MINUS_TWO_THIRDS_PI).inverse());
+        assertRotationEquals(StandardRotations.PLUS_DIAGONAL_TWO_THIRDS_PI, QuaternionRotation.fromAxisAngle(MINUS_DIAGONAL, TWO_THIRDS_PI).inverse());
 
-        assertRotationEquals(StandardRotations.MINUS_DIAGONAL_TWO_THIRDS_PI, QuaternionRotation.fromAxisAngle(MINUS_DIAGONAL, MINUS_TWO_THIRDS_PI).getInverse());
-        assertRotationEquals(StandardRotations.MINUS_DIAGONAL_TWO_THIRDS_PI, QuaternionRotation.fromAxisAngle(PLUS_DIAGONAL, TWO_THIRDS_PI).getInverse());
+        assertRotationEquals(StandardRotations.MINUS_DIAGONAL_TWO_THIRDS_PI, QuaternionRotation.fromAxisAngle(MINUS_DIAGONAL, MINUS_TWO_THIRDS_PI).inverse());
+        assertRotationEquals(StandardRotations.MINUS_DIAGONAL_TWO_THIRDS_PI, QuaternionRotation.fromAxisAngle(PLUS_DIAGONAL, TWO_THIRDS_PI).inverse());
     }
 
     @Test
-    public void testGetInverse_undoesOriginalRotation() {
+    public void testInverse_undoesOriginalRotation() {
         EuclideanTestUtils.permuteSkipZero(-5, 5, 1, (x, y, z) -> {
             // arrange
             Vector3D vec = Vector3D.of(x, y, z);
 
             QuaternionRotation rot = QuaternionRotation.fromAxisAngle(vec, 0.75 * Geometry.PI);
-            QuaternionRotation neg = rot.getInverse();
+            QuaternionRotation neg = rot.inverse();
 
             // act/assert
             EuclideanTestUtils.assertCoordinatesEqual(PLUS_DIAGONAL, neg.apply(rot.apply(PLUS_DIAGONAL)), EPS);
@@ -604,7 +604,7 @@ public class QuaternionRotationTest {
             QuaternionRotation result = QuaternionRotation.of(slerp.apply(t));
 
             Vector3D slerpVec = result.apply(vec);
-            Assert.assertEquals(1, slerpVec.getNorm(), EPS);
+            Assert.assertEquals(1, slerpVec.norm(), EPS);
 
             // make sure that we're steadily progressing to the end angle
             double angle = slerpVec.angle(startVec);
@@ -1064,7 +1064,7 @@ public class QuaternionRotationTest {
         Assert.assertEquals(Geometry.HALF_PI, q.getAngle(), EPS);
 
         EuclideanTestUtils.assertCoordinatesEqual(u2, q.apply(u1), EPS);
-        EuclideanTestUtils.assertCoordinatesEqual(u1, q.getInverse().apply(u2), EPS);
+        EuclideanTestUtils.assertCoordinatesEqual(u1, q.inverse().apply(u2), EPS);
     }
 
     @Test
@@ -1083,7 +1083,7 @@ public class QuaternionRotationTest {
         Assert.assertEquals(Geometry.ZERO_PI, q.getAngle(), EPS);
 
         EuclideanTestUtils.assertCoordinatesEqual(Vector3D.of(0, 2, 0), q.apply(u1), EPS);
-        EuclideanTestUtils.assertCoordinatesEqual(Vector3D.of(0, 2, 0), q.getInverse().apply(u2), EPS);
+        EuclideanTestUtils.assertCoordinatesEqual(Vector3D.of(0, 2, 0), q.inverse().apply(u2), EPS);
     }
 
     @Test
@@ -1102,7 +1102,7 @@ public class QuaternionRotationTest {
         Assert.assertEquals(Geometry.ZERO_PI, q.getAngle(), EPS);
 
         EuclideanTestUtils.assertCoordinatesEqual(Vector3D.of(0, 2, 0), q.apply(u1), EPS);
-        EuclideanTestUtils.assertCoordinatesEqual(Vector3D.of(0, 3, 0), q.getInverse().apply(u2), EPS);
+        EuclideanTestUtils.assertCoordinatesEqual(Vector3D.of(0, 3, 0), q.inverse().apply(u2), EPS);
     }
 
     @Test
@@ -1121,7 +1121,7 @@ public class QuaternionRotationTest {
         Assert.assertEquals(Geometry.PI, q.getAngle(), EPS);
 
         EuclideanTestUtils.assertCoordinatesEqual(Vector3D.of(0, -2, 0), q.apply(u1), EPS);
-        EuclideanTestUtils.assertCoordinatesEqual(Vector3D.of(0, 3, 0), q.getInverse().apply(u2), EPS);
+        EuclideanTestUtils.assertCoordinatesEqual(Vector3D.of(0, 3, 0), q.inverse().apply(u2), EPS);
     }
 
     @Test
@@ -1136,7 +1136,7 @@ public class QuaternionRotationTest {
 
             // assert
             Assert.assertEquals(0.0, q.apply(u1).angle(u2), EPS);
-            Assert.assertEquals(0.0, q.getInverse().apply(u2).angle(u1), EPS);
+            Assert.assertEquals(0.0, q.inverse().apply(u2).angle(u1), EPS);
 
             double angle = q.getAngle();
             Assert.assertTrue(angle >= Geometry.ZERO_PI);
@@ -1173,7 +1173,7 @@ public class QuaternionRotationTest {
         QuaternionRotation q = QuaternionRotation.createBasisRotation(u1, u2, v1, v2);
 
         // assert
-        QuaternionRotation qInv = q.getInverse();
+        QuaternionRotation qInv = q.inverse();
 
         EuclideanTestUtils.assertCoordinatesEqual(v1, q.apply(u1), EPS);
         EuclideanTestUtils.assertCoordinatesEqual(v2, q.apply(u2), EPS);
@@ -1197,7 +1197,7 @@ public class QuaternionRotationTest {
         QuaternionRotation q = QuaternionRotation.createBasisRotation(u1, u2, v1, v2);
 
         // assert
-        QuaternionRotation qInv = q.getInverse();
+        QuaternionRotation qInv = q.inverse();
 
         EuclideanTestUtils.assertCoordinatesEqual(v1, q.apply(u1), EPS);
         EuclideanTestUtils.assertCoordinatesEqual(v2, q.apply(u2), EPS);
@@ -1206,7 +1206,7 @@ public class QuaternionRotationTest {
         EuclideanTestUtils.assertCoordinatesEqual(u2, qInv.apply(v2), EPS);
 
         assertRotationEquals(StandardRotations.PLUS_DIAGONAL_TWO_THIRDS_PI, q);
-        assertRotationEquals(StandardRotations.MINUS_DIAGONAL_TWO_THIRDS_PI, q.getInverse());
+        assertRotationEquals(StandardRotations.MINUS_DIAGONAL_TWO_THIRDS_PI, q.inverse());
     }
 
     @Test
@@ -1222,7 +1222,7 @@ public class QuaternionRotationTest {
         QuaternionRotation q = QuaternionRotation.createBasisRotation(u1, u2, v1, v2);
 
         // assert
-        QuaternionRotation qInv = q.getInverse();
+        QuaternionRotation qInv = q.inverse();
 
         EuclideanTestUtils.assertCoordinatesEqual(v1, q.apply(u1), EPS);
         EuclideanTestUtils.assertCoordinatesEqual(v2, q.apply(u2), EPS);
@@ -1246,7 +1246,7 @@ public class QuaternionRotationTest {
         QuaternionRotation q = QuaternionRotation.createBasisRotation(u1, u2, v1, v2);
 
         // assert
-        QuaternionRotation qInv = q.getInverse();
+        QuaternionRotation qInv = q.inverse();
 
         EuclideanTestUtils.assertCoordinatesEqual(u1, q.apply(u1), EPS);
         EuclideanTestUtils.assertCoordinatesEqual(u2, q.apply(u2), EPS);
@@ -1270,7 +1270,7 @@ public class QuaternionRotationTest {
         QuaternionRotation q = QuaternionRotation.createBasisRotation(u1, u2, v1, v2);
 
         // assert
-        QuaternionRotation qInv = q.getInverse();
+        QuaternionRotation qInv = q.inverse();
 
         EuclideanTestUtils.assertCoordinatesEqual(Vector3D.of(0, 2, 0), q.apply(u1), EPS);
         EuclideanTestUtils.assertCoordinatesEqual(Vector3D.of(-0.5, 1, 0), q.apply(u2), EPS);
@@ -1299,7 +1299,7 @@ public class QuaternionRotationTest {
 
             // act
             QuaternionRotation q = QuaternionRotation.createBasisRotation(u1, u2, v1, v2);
-            QuaternionRotation qInv = q.getInverse();
+            QuaternionRotation qInv = q.inverse();
 
             // assert
             EuclideanTestUtils.assertCoordinatesEqual(v1Dir, q.apply(u1Dir), EPS);
@@ -1316,9 +1316,9 @@ public class QuaternionRotationTest {
             Vector3D transformedY = q.apply(Vector3D.PLUS_Y);
             Vector3D transformedZ = q.apply(Vector3D.PLUS_Z);
 
-            Assert.assertEquals(1.0, transformedX.getNorm(), EPS);
-            Assert.assertEquals(1.0, transformedY.getNorm(), EPS);
-            Assert.assertEquals(1.0, transformedZ.getNorm(), EPS);
+            Assert.assertEquals(1.0, transformedX.norm(), EPS);
+            Assert.assertEquals(1.0, transformedY.norm(), EPS);
+            Assert.assertEquals(1.0, transformedZ.norm(), EPS);
 
             Assert.assertEquals(0.0, transformedX.dotProduct(transformedY), EPS);
             Assert.assertEquals(0.0, transformedX.dotProduct(transformedZ), EPS);

--- a/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/threed/rotation/QuaternionRotationTest.java
+++ b/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/threed/rotation/QuaternionRotationTest.java
@@ -19,7 +19,6 @@ package org.apache.commons.geometry.euclidean.threed.rotation;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.UnaryOperator;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.commons.geometry.core.Geometry;
@@ -30,9 +29,6 @@ import org.apache.commons.geometry.euclidean.EuclideanTestUtils;
 import org.apache.commons.geometry.euclidean.internal.Vectors;
 import org.apache.commons.geometry.euclidean.threed.AffineTransformMatrix3D;
 import org.apache.commons.geometry.euclidean.threed.Vector3D;
-import org.apache.commons.geometry.euclidean.threed.rotation.AxisAngleSequence;
-import org.apache.commons.geometry.euclidean.threed.rotation.AxisSequence;
-import org.apache.commons.geometry.euclidean.threed.rotation.QuaternionRotation;
 import org.apache.commons.numbers.angle.PlaneAngleRadians;
 import org.apache.commons.numbers.core.Precision;
 import org.apache.commons.numbers.quaternion.Quaternion;
@@ -640,7 +636,7 @@ public class QuaternionRotationTest {
     }
 
     @Test
-    public void testSlerp_quaternionsHaveMinusOneDotProduct() {
+    public void testSlerp_inputQuaternionsHaveMinusOneDotProduct() {
         // arrange
         QuaternionRotation q1 = QuaternionRotation.of(1, 0, 0, 1); // pi/2 around +z
         QuaternionRotation q2 = QuaternionRotation.of(-1, 0, 0, -1); // 3pi/2 around -z
@@ -656,7 +652,7 @@ public class QuaternionRotationTest {
     }
 
     @Test
-    public void testSlerp_quaternionIsNormalizedForAllT() {
+    public void testSlerp_outputQuaternionIsNormalizedForAllT() {
         // arrange
         QuaternionRotation q1 = QuaternionRotation.fromAxisAngle(Vector3D.PLUS_Z, 0.25 * Geometry.PI);
         QuaternionRotation q2 = QuaternionRotation.fromAxisAngle(Vector3D.PLUS_Z, 0.75 * Geometry.PI);
@@ -670,11 +666,7 @@ public class QuaternionRotationTest {
             QuaternionRotation result = QuaternionRotation.of(q1.slerp(q2).apply(t));
 
             // assert
-            Assert.assertEquals(1.0, Vectors.norm(result.getQuaternion().getX(),
-                                                  result.getQuaternion().getY(),
-                                                  result.getQuaternion().getZ(),
-                                                  result.getQuaternion().getW()),
-                                EPS);
+            Assert.assertEquals(1.0, result.getQuaternion().norm(), EPS);
         }
     }
 
@@ -1336,7 +1328,7 @@ public class QuaternionRotationTest {
             EuclideanTestUtils.assertCoordinatesEqual(transformedZ.normalize(),
                     transformedX.normalize().crossProduct(transformedY.normalize()), EPS);
 
-            Assert.assertEquals(1.0, Vectors.norm(q.getQuaternion().getX(), q.getQuaternion().getY(), q.getQuaternion().getZ(), q.getQuaternion().getW()), EPS);
+            Assert.assertEquals(1.0, q.getQuaternion().norm(), EPS);
         });
     }
 

--- a/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/twod/AffineTransformMatrix2DTest.java
+++ b/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/twod/AffineTransformMatrix2DTest.java
@@ -642,7 +642,7 @@ public class AffineTransformMatrix2DTest {
 
             Vector2D expectedVec = vec
                     .add(translation1)
-                    .scalarMultiply(scale)
+                    .multiply(scale)
                     .add(translation2);
 
             EuclideanTestUtils.assertCoordinatesEqual(expectedVec, transform.apply(vec), EPS);
@@ -693,7 +693,7 @@ public class AffineTransformMatrix2DTest {
 
             Vector2D expectedVec = vec
                     .add(translation1)
-                    .scalarMultiply(scale)
+                    .multiply(scale)
                     .add(translation2);
 
             EuclideanTestUtils.assertCoordinatesEqual(expectedVec, transform.apply(vec), EPS);
@@ -701,9 +701,9 @@ public class AffineTransformMatrix2DTest {
     }
 
     @Test
-    public void testGetInverse_identity() {
+    public void testInverse_identity() {
         // act
-        AffineTransformMatrix2D inverse = AffineTransformMatrix2D.identity().getInverse();
+        AffineTransformMatrix2D inverse = AffineTransformMatrix2D.identity().inverse();
 
         // assert
         double[] expected = {
@@ -714,14 +714,14 @@ public class AffineTransformMatrix2DTest {
     }
 
     @Test
-    public void testGetInverse_multiplyByInverse_producesIdentity() {
+    public void testInverse_multiplyByInverse_producesIdentity() {
         // arrange
         AffineTransformMatrix2D a = AffineTransformMatrix2D.of(
                     1, 3, 7,
                     2, 4, 9
                 );
 
-        AffineTransformMatrix2D inv = a.getInverse();
+        AffineTransformMatrix2D inv = a.inverse();
 
         // act
         AffineTransformMatrix2D result = inv.multiply(a);
@@ -735,12 +735,12 @@ public class AffineTransformMatrix2DTest {
     }
 
     @Test
-    public void testGetInverse_translate() {
+    public void testInverse_translate() {
         // arrange
         AffineTransformMatrix2D transform = AffineTransformMatrix2D.createTranslation(1, -2);
 
         // act
-        AffineTransformMatrix2D inverse = transform.getInverse();
+        AffineTransformMatrix2D inverse = transform.inverse();
 
         // assert
         double[] expected = {
@@ -751,12 +751,12 @@ public class AffineTransformMatrix2DTest {
     }
 
     @Test
-    public void testGetInverse_scale() {
+    public void testInverse_scale() {
         // arrange
         AffineTransformMatrix2D transform = AffineTransformMatrix2D.createScale(10, -2);
 
         // act
-        AffineTransformMatrix2D inverse = transform.getInverse();
+        AffineTransformMatrix2D inverse = transform.inverse();
 
         // assert
         double[] expected = {
@@ -767,12 +767,12 @@ public class AffineTransformMatrix2DTest {
     }
 
     @Test
-    public void testGetInverse_rotate() {
+    public void testInverse_rotate() {
         // arrange
         AffineTransformMatrix2D transform = AffineTransformMatrix2D.createRotation(Geometry.HALF_PI);
 
         // act
-        AffineTransformMatrix2D inverse = transform.getInverse();
+        AffineTransformMatrix2D inverse = transform.inverse();
 
         // assert
         double[] expected = {
@@ -783,13 +783,13 @@ public class AffineTransformMatrix2DTest {
     }
 
     @Test
-    public void testGetInverse_rotate_aroundCenter() {
+    public void testInverse_rotate_aroundCenter() {
         // arrange
         Vector2D center = Vector2D.of(1, 2);
         AffineTransformMatrix2D transform = AffineTransformMatrix2D.createRotation(center, Geometry.HALF_PI);
 
         // act
-        AffineTransformMatrix2D inverse = transform.getInverse();
+        AffineTransformMatrix2D inverse = transform.inverse();
 
         // assert
         double[] expected = {
@@ -800,7 +800,7 @@ public class AffineTransformMatrix2DTest {
     }
 
     @Test
-    public void testGetInverse_undoesOriginalTransform() {
+    public void testInverse_undoesOriginalTransform() {
         // arrange
         Vector2D v1 = Vector2D.ZERO;
         Vector2D v2 = Vector2D.PLUS_X;
@@ -818,7 +818,7 @@ public class AffineTransformMatrix2DTest {
                         .rotate(x / 4)
                         .rotate(center, y / 2);
 
-            AffineTransformMatrix2D inverse = transform.getInverse();
+            AffineTransformMatrix2D inverse = transform.inverse();
 
             EuclideanTestUtils.assertCoordinatesEqual(v1, inverse.apply(transform.apply(v1)), EPS);
             EuclideanTestUtils.assertCoordinatesEqual(v2, inverse.apply(transform.apply(v2)), EPS);
@@ -828,48 +828,48 @@ public class AffineTransformMatrix2DTest {
     }
 
     @Test
-    public void testGetInverse_nonInvertible() {
+    public void testInverse_nonInvertible() {
         // act/assert
         GeometryTestUtils.assertThrows(() -> {
             AffineTransformMatrix2D.of(
                     0, 0, 0,
-                    0, 0, 0).getInverse();
+                    0, 0, 0).inverse();
         }, NonInvertibleTransformException.class, "Transform is not invertible; matrix determinant is 0.0");
 
         GeometryTestUtils.assertThrows(() -> {
             AffineTransformMatrix2D.of(
                     1, 0, 0,
-                    0, Double.NaN, 0).getInverse();
+                    0, Double.NaN, 0).inverse();
         }, NonInvertibleTransformException.class, "Transform is not invertible; matrix determinant is NaN");
 
         GeometryTestUtils.assertThrows(() -> {
             AffineTransformMatrix2D.of(
                     1, 0, 0,
-                    0, Double.NEGATIVE_INFINITY, 0).getInverse();
+                    0, Double.NEGATIVE_INFINITY, 0).inverse();
         }, NonInvertibleTransformException.class, "Transform is not invertible; matrix determinant is -Infinity");
 
         GeometryTestUtils.assertThrows(() -> {
             AffineTransformMatrix2D.of(
                     Double.POSITIVE_INFINITY, 0, 0,
-                    0, 1, 0).getInverse();
+                    0, 1, 0).inverse();
         }, NonInvertibleTransformException.class, "Transform is not invertible; matrix determinant is Infinity");
 
         GeometryTestUtils.assertThrows(() -> {
             AffineTransformMatrix2D.of(
                     1, 0, Double.NaN,
-                    0, 1, 0).getInverse();
+                    0, 1, 0).inverse();
         }, NonInvertibleTransformException.class, "Transform is not invertible; invalid matrix element: NaN");
 
         GeometryTestUtils.assertThrows(() -> {
             AffineTransformMatrix2D.of(
                     1, 0, Double.POSITIVE_INFINITY,
-                    0, 1, 0).getInverse();
+                    0, 1, 0).inverse();
         }, NonInvertibleTransformException.class, "Transform is not invertible; invalid matrix element: Infinity");
 
         GeometryTestUtils.assertThrows(() -> {
             AffineTransformMatrix2D.of(
                     1, 0, Double.NEGATIVE_INFINITY,
-                    0, 1, 0).getInverse();
+                    0, 1, 0).inverse();
         }, NonInvertibleTransformException.class, "Transform is not invertible; invalid matrix element: -Infinity");
     }
 

--- a/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/twod/Vector2DTest.java
+++ b/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/twod/Vector2DTest.java
@@ -360,20 +360,20 @@ public class Vector2DTest {
         Vector2D v3 = Vector2D.of(-1, 0);
 
         // act/assert
-        Assert.assertEquals(2, v1.dotProduct(v1), EPS);
-        Assert.assertEquals(41, v2.dotProduct(v2), EPS);
-        Assert.assertEquals(1, v3.dotProduct(v3), EPS);
+        Assert.assertEquals(2, v1.dot(v1), EPS);
+        Assert.assertEquals(41, v2.dot(v2), EPS);
+        Assert.assertEquals(1, v3.dot(v3), EPS);
 
-        Assert.assertEquals(9, v1.dotProduct(v2), EPS);
-        Assert.assertEquals(9, v2.dotProduct(v1), EPS);
+        Assert.assertEquals(9, v1.dot(v2), EPS);
+        Assert.assertEquals(9, v2.dot(v1), EPS);
 
-        Assert.assertEquals(-1, v1.dotProduct(v3), EPS);
-        Assert.assertEquals(-1, v3.dotProduct(v1), EPS);
+        Assert.assertEquals(-1, v1.dot(v3), EPS);
+        Assert.assertEquals(-1, v3.dot(v1), EPS);
 
-        Assert.assertEquals(1, Vector2D.PLUS_X.dotProduct(Vector2D.PLUS_X), EPS);
-        Assert.assertEquals(0, Vector2D.PLUS_X.dotProduct(Vector2D.PLUS_Y), EPS);
-        Assert.assertEquals(-1, Vector2D.PLUS_X.dotProduct(Vector2D.MINUS_X), EPS);
-        Assert.assertEquals(0, Vector2D.PLUS_X.dotProduct(Vector2D.MINUS_Y), EPS);
+        Assert.assertEquals(1, Vector2D.PLUS_X.dot(Vector2D.PLUS_X), EPS);
+        Assert.assertEquals(0, Vector2D.PLUS_X.dot(Vector2D.PLUS_Y), EPS);
+        Assert.assertEquals(-1, Vector2D.PLUS_X.dot(Vector2D.MINUS_X), EPS);
+        Assert.assertEquals(0, Vector2D.PLUS_X.dot(Vector2D.MINUS_Y), EPS);
     }
 
     @Test
@@ -406,7 +406,7 @@ public class Vector2DTest {
 
             // assert
             Assert.assertEquals(1.0, ortho.norm(), EPS);
-            Assert.assertEquals(0.0, v.dotProduct(ortho), EPS);
+            Assert.assertEquals(0.0, v.dot(ortho), EPS);
         }
     }
 
@@ -523,9 +523,9 @@ public class Vector2DTest {
         Vector2D p5 = Vector2D.of(2, 1);
 
         // act/assert
-        Assert.assertEquals(0.0, p3.crossProduct(p1, p2), EPS);
-        Assert.assertEquals(1.0, p4.crossProduct(p1, p2), EPS);
-        Assert.assertEquals(-1.0, p5.crossProduct(p1, p2), EPS);
+        Assert.assertEquals(0.0, p3.cross(p1, p2), EPS);
+        Assert.assertEquals(1.0, p4.cross(p1, p2), EPS);
+        Assert.assertEquals(-1.0, p5.cross(p1, p2), EPS);
     }
 
     @Test

--- a/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/twod/Vector2DTest.java
+++ b/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/twod/Vector2DTest.java
@@ -131,27 +131,27 @@ public class Vector2DTest {
     @Test
     public void testNorm() {
         // act/assert
-        Assert.assertEquals(0.0, Vector2D.of(0, 0).getNorm(), EPS);
+        Assert.assertEquals(0.0, Vector2D.of(0, 0).norm(), EPS);
 
-        Assert.assertEquals(5.0, Vector2D.of(3, 4).getNorm(), EPS);
-        Assert.assertEquals(5.0, Vector2D.of(3, -4).getNorm(), EPS);
-        Assert.assertEquals(5.0, Vector2D.of(-3, 4).getNorm(), EPS);
-        Assert.assertEquals(5.0, Vector2D.of(-3, -4).getNorm(), EPS);
+        Assert.assertEquals(5.0, Vector2D.of(3, 4).norm(), EPS);
+        Assert.assertEquals(5.0, Vector2D.of(3, -4).norm(), EPS);
+        Assert.assertEquals(5.0, Vector2D.of(-3, 4).norm(), EPS);
+        Assert.assertEquals(5.0, Vector2D.of(-3, -4).norm(), EPS);
 
-        Assert.assertEquals(Math.sqrt(5.0), Vector2D.of(-1, -2).getNorm(), EPS);
+        Assert.assertEquals(Math.sqrt(5.0), Vector2D.of(-1, -2).norm(), EPS);
     }
 
     @Test
     public void testNormSq() {
         // act/assert
-        Assert.assertEquals(0.0, Vector2D.of(0, 0).getNormSq(), EPS);
+        Assert.assertEquals(0.0, Vector2D.of(0, 0).normSq(), EPS);
 
-        Assert.assertEquals(25.0, Vector2D.of(3, 4).getNormSq(), EPS);
-        Assert.assertEquals(25.0, Vector2D.of(3, -4).getNormSq(), EPS);
-        Assert.assertEquals(25.0, Vector2D.of(-3, 4).getNormSq(), EPS);
-        Assert.assertEquals(25.0, Vector2D.of(-3, -4).getNormSq(), EPS);
+        Assert.assertEquals(25.0, Vector2D.of(3, 4).normSq(), EPS);
+        Assert.assertEquals(25.0, Vector2D.of(3, -4).normSq(), EPS);
+        Assert.assertEquals(25.0, Vector2D.of(-3, 4).normSq(), EPS);
+        Assert.assertEquals(25.0, Vector2D.of(-3, -4).normSq(), EPS);
 
-        Assert.assertEquals(5.0, Vector2D.of(-1, -2).getNormSq(), EPS);
+        Assert.assertEquals(5.0, Vector2D.of(-1, -2).normSq(), EPS);
     }
 
     @Test
@@ -192,7 +192,7 @@ public class Vector2DTest {
 
         for (int i = -10; i <= 10; i++) {
             final double mag = i;
-            Assert.assertEquals(Math.abs(mag), v.withNorm(mag).getNorm(), eps);
+            Assert.assertEquals(Math.abs(mag), v.withNorm(mag).norm(), eps);
         }
     }
 
@@ -309,13 +309,13 @@ public class Vector2DTest {
     @Test
     public void testScalarMultiply() {
         // act/assert
-        checkVector(Vector2D.of(1, 2).scalarMultiply(0), 0, 0);
+        checkVector(Vector2D.of(1, 2).multiply(0), 0, 0);
 
-        checkVector(Vector2D.of(1, 2).scalarMultiply(3), 3, 6);
-        checkVector(Vector2D.of(1, 2).scalarMultiply(-3), -3, -6);
+        checkVector(Vector2D.of(1, 2).multiply(3), 3, 6);
+        checkVector(Vector2D.of(1, 2).multiply(-3), -3, -6);
 
-        checkVector(Vector2D.of(2, 3).scalarMultiply(1.5), 3, 4.5);
-        checkVector(Vector2D.of(2, 3).scalarMultiply(-1.5), -3, -4.5);
+        checkVector(Vector2D.of(2, 3).multiply(1.5), 3, 4.5);
+        checkVector(Vector2D.of(2, 3).multiply(-1.5), -3, -4.5);
     }
 
     @Test
@@ -405,7 +405,7 @@ public class Vector2DTest {
             Vector2D ortho = v.orthogonal();
 
             // assert
-            Assert.assertEquals(1.0, ortho.getNorm(), EPS);
+            Assert.assertEquals(1.0, ortho.norm(), EPS);
             Assert.assertEquals(0.0, v.dotProduct(ortho), EPS);
         }
     }

--- a/commons-geometry-hull/src/main/java/org/apache/commons/geometry/euclidean/twod/hull/AklToussaintHeuristic.java
+++ b/commons-geometry-hull/src/main/java/org/apache/commons/geometry/euclidean/twod/hull/AklToussaintHeuristic.java
@@ -129,7 +129,7 @@ public final class AklToussaintHeuristic {
         }
 
         // get the location of the point relative to the first two vertices
-        final double last = v0.crossProduct(v1, v2);
+        final double last = v0.cross(v1, v2);
         final int size = quadrilateralPoints.size();
         // loop through the rest of the vertices
         for (int i = 1; i < size; i++) {
@@ -143,7 +143,7 @@ public final class AklToussaintHeuristic {
             // do side of line test: multiply the last location with this location
             // if they are the same sign then the operation will yield a positive result
             // -x * -y = +xy, x * y = +xy, -x * y = -xy, x * -y = -xy
-            if (last * v0.crossProduct(v1, v2) < 0) {
+            if (last * v0.cross(v1, v2) < 0) {
                 return false;
             }
         }

--- a/commons-geometry-hull/src/test/java/org/apache/commons/geometry/euclidean/twod/hull/ConvexHullGenerator2DAbstractTest.java
+++ b/commons-geometry-hull/src/test/java/org/apache/commons/geometry/euclidean/twod/hull/ConvexHullGenerator2DAbstractTest.java
@@ -396,8 +396,8 @@ public abstract class ConvexHullGenerator2DAbstractTest {
             Vector2D d1 = p2.subtract(p1);
             Vector2D d2 = p3.subtract(p2);
 
-            Assert.assertTrue(d1.getNorm() > 1e-10);
-            Assert.assertTrue(d2.getNorm() > 1e-10);
+            Assert.assertTrue(d1.norm() > 1e-10);
+            Assert.assertTrue(d2.norm() > 1e-10);
 
             final double cross = LinearCombination.value(d1.getX(), d2.getY(), -d1.getY(), d2.getX());
             final int cmp = Precision.compareTo(cross, 0.0, tolerance);

--- a/commons-geometry-spherical/src/main/java/org/apache/commons/geometry/spherical/twod/Circle.java
+++ b/commons-geometry-spherical/src/main/java/org/apache/commons/geometry/spherical/twod/Circle.java
@@ -68,7 +68,7 @@ public class Circle implements Hyperplane<S2Point>, Embedding<S2Point, S1Point> 
      * @param tolerance tolerance below which close sub-arcs are merged together
      */
     public Circle(final S2Point first, final S2Point second, final double tolerance) {
-        reset(first.getVector().crossProduct(second.getVector()));
+        reset(first.getVector().cross(second.getVector()));
         this.tolerance = tolerance;
     }
 
@@ -109,7 +109,7 @@ public class Circle implements Hyperplane<S2Point>, Embedding<S2Point, S1Point> 
     public void reset(final Vector3D newPole) {
         this.pole = newPole.normalize();
         this.x    = newPole.orthogonal();
-        this.y    = newPole.crossProduct(x).normalize();
+        this.y    = newPole.cross(x).normalize();
     }
 
     /** Revert the instance.
@@ -160,7 +160,7 @@ public class Circle implements Hyperplane<S2Point>, Embedding<S2Point, S1Point> 
      * @see #toSubSpace(Point)
      */
     public double getPhase(final Vector3D direction) {
-        return Math.PI + Math.atan2(-direction.dotProduct(y), -direction.dotProduct(x));
+        return Math.PI + Math.atan2(-direction.dot(y), -direction.dot(x));
     }
 
     /** {@inheritDoc}
@@ -275,7 +275,7 @@ public class Circle implements Hyperplane<S2Point>, Embedding<S2Point, S1Point> 
     @Override
     public boolean sameOrientationAs(final Hyperplane<S2Point> other) {
         final Circle otherC = (Circle) other;
-        return pole.dotProduct(otherC.pole) >= 0.0;
+        return pole.dot(otherC.pole) >= 0.0;
     }
 
     /** Get a {@link org.apache.commons.geometry.core.partitioning.Transform

--- a/commons-geometry-spherical/src/main/java/org/apache/commons/geometry/spherical/twod/PropertiesComputer.java
+++ b/commons-geometry-spherical/src/main/java/org/apache/commons/geometry/spherical/twod/PropertiesComputer.java
@@ -110,8 +110,8 @@ class PropertiesComputer implements BSPTreeVisitor<S2Point> {
             final Vector3D previousPole = e.getCircle().getPole();
             final Vector3D nextPole     = e.getEnd().getOutgoing().getCircle().getPole();
             final Vector3D point        = e.getEnd().getLocation().getVector();
-            double alpha = Math.atan2(nextPole.dotProduct(point.crossProduct(previousPole)),
-                                          - nextPole.dotProduct(previousPole));
+            double alpha = Math.atan2(nextPole.dot(point.cross(previousPole)),
+                                          - nextPole.dot(previousPole));
             if (alpha < 0) {
                 alpha += Geometry.TWO_PI;
             }

--- a/commons-geometry-spherical/src/main/java/org/apache/commons/geometry/spherical/twod/PropertiesComputer.java
+++ b/commons-geometry-spherical/src/main/java/org/apache/commons/geometry/spherical/twod/PropertiesComputer.java
@@ -157,7 +157,7 @@ class PropertiesComputer implements BSPTreeVisitor<S2Point> {
      * @return barycenter
      */
     public S2Point getBarycenter() {
-        if (summedBarycenter.getNormSq() == 0) {
+        if (summedBarycenter.normSq() == 0) {
             return S2Point.NaN;
         } else {
             return S2Point.ofVector(summedBarycenter);

--- a/commons-geometry-spherical/src/main/java/org/apache/commons/geometry/spherical/twod/SphericalPolygonsSet.java
+++ b/commons-geometry-spherical/src/main/java/org/apache/commons/geometry/spherical/twod/SphericalPolygonsSet.java
@@ -508,7 +508,7 @@ public class SphericalPolygonsSet extends AbstractRegion<S2Point, S1Point> {
 
         // convert to 3D sphere to spherical cap
         final double r = enclosing3D.getRadius();
-        final double h = enclosing3D.getCenter().getNorm();
+        final double h = enclosing3D.getCenter().norm();
         if (h < getTolerance()) {
             // the 3D sphere is centered on the unit sphere and covers it
             // fall back to a crude approximation, based only on outside convex cells

--- a/commons-geometry-spherical/src/main/java/org/apache/commons/geometry/spherical/twod/SphericalPolygonsSet.java
+++ b/commons-geometry-spherical/src/main/java/org/apache/commons/geometry/spherical/twod/SphericalPolygonsSet.java
@@ -157,7 +157,7 @@ public class SphericalPolygonsSet extends AbstractRegion<S2Point, S1Point> {
     private static S2Point[] createRegularPolygonVertices(final Vector3D center, final Vector3D meridian,
                                                           final double outsideRadius, final int n) {
         final S2Point[] array = new S2Point[n];
-        final QuaternionRotation r0 = QuaternionRotation.fromAxisAngle(center.crossProduct(meridian),
+        final QuaternionRotation r0 = QuaternionRotation.fromAxisAngle(center.cross(meridian),
                                          outsideRadius);
         array[0] = S2Point.ofVector(r0.apply(center));
 

--- a/commons-geometry-spherical/src/test/java/org/apache/commons/geometry/spherical/twod/CircleTest.java
+++ b/commons-geometry-spherical/src/test/java/org/apache/commons/geometry/spherical/twod/CircleTest.java
@@ -53,7 +53,7 @@ public class CircleTest {
         Assert.assertEquals(0.5 * Math.PI, circle.getXAxis().angle(circle.getPole()), 1.0e-10);
         Assert.assertEquals(0.5 * Math.PI, circle.getPole().angle(circle.getYAxis()), 1.0e-10);
         Assert.assertEquals(0.0,
-                            circle.getPole().distance(circle.getXAxis().crossProduct(circle.getYAxis())),
+                            circle.getPole().distance(circle.getXAxis().cross(circle.getYAxis())),
                             1.0e-10);
     }
 
@@ -67,7 +67,7 @@ public class CircleTest {
         Assert.assertEquals(0.5 * Math.PI, reversed.getXAxis().angle(reversed.getPole()), 1.0e-10);
         Assert.assertEquals(0.5 * Math.PI, reversed.getPole().angle(reversed.getYAxis()), 1.0e-10);
         Assert.assertEquals(0.0,
-                            reversed.getPole().distance(reversed.getXAxis().crossProduct(reversed.getYAxis())),
+                            reversed.getPole().distance(reversed.getXAxis().cross(reversed.getYAxis())),
                             1.0e-10);
 
         Assert.assertEquals(0, circle.getXAxis().angle(reversed.getXAxis()), 1.0e-10);
@@ -84,8 +84,8 @@ public class CircleTest {
         Vector3D p = Vector3D.of(1, 2, -4);
         Vector3D samePhase = circle.getPointAt(circle.getPhase(p));
         Assert.assertEquals(0.0,
-                            circle.getPole().crossProduct(p).angle(
-                                           circle.getPole().crossProduct(samePhase)),
+                            circle.getPole().cross(p).angle(
+                                           circle.getPole().cross(samePhase)),
                             1.0e-10);
         Assert.assertEquals(0.5 * Math.PI, circle.getPole().angle(samePhase), 1.0e-10);
         Assert.assertEquals(circle.getPhase(p), circle.getPhase(samePhase), 1.0e-10);


### PR DESCRIPTION
Standardizing method names with commons-numbers and shortening names where possible. This also includes some minor cleanup.