### PR TITLE
GEOMETRY-39: Removing unneeded checks on PlaneAngleRadians output

### DIFF
--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/PolarCoordinates.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/PolarCoordinates.java
@@ -230,14 +230,8 @@ public final class PolarCoordinates implements Spatial, Serializable {
      * @return equivalent azimuth value in the range {@code [0, 2pi)}.
      */
     public static double normalizeAzimuth(double azimuth) {
-        if (Double.isFinite(azimuth) && (azimuth < 0.0 || azimuth >= Geometry.TWO_PI)) {
+        if (Double.isFinite(azimuth)) {
             azimuth = PlaneAngleRadians.normalizeBetweenZeroAndTwoPi(azimuth);
-
-            // azimuth is now in the range [0, 2pi] but we want it to be in the range
-            // [0, 2pi) in order to have completely unique coordinates
-            if (azimuth >= Geometry.TWO_PI) {
-                azimuth -= Geometry.TWO_PI;
-            }
         }
 
         return azimuth;


### PR DESCRIPTION
Based on NUMBERS-93, we don't need to ensure that the output from PlaneAngleRadians normalize methods is less than the upper bound.