### PR TITLE
GEOMETRY-60: Bumping Jacoco Version 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <geometry.parent.dir>${basedir}</geometry.parent.dir>
 
     <!-- Temporary fix to support Java 8 -->
-    <commons.jacoco.version>0.8.2</commons.jacoco.version>
+    <commons.jacoco.version>0.8.4</commons.jacoco.version>
     <commons.jacoco.classRatio>0.96</commons.jacoco.classRatio>
     <commons.jacoco.instructionRatio>0.8</commons.jacoco.instructionRatio>
     <commons.jacoco.methodRatio>0.8</commons.jacoco.methodRatio>


### PR DESCRIPTION
Bumping Jacoco version to 0.8.4 for compatibility with JDK 13.