### PR TITLE
GEOMETRY-63: Minor Cleanup

### DIFF
--- a/commons-geometry-core/src/main/java/org/apache/commons/geometry/core/partitioning/AbstractConvexHyperplaneBoundedRegion.java
+++ b/commons-geometry-core/src/main/java/org/apache/commons/geometry/core/partitioning/AbstractConvexHyperplaneBoundedRegion.java
@@ -255,29 +255,44 @@ public abstract class AbstractConvexHyperplaneBoundedRegion<P extends Point<P>, 
             final List<S> minusBoundaries = new ArrayList<>();
             final List<S> plusBoundaries = new ArrayList<>();
 
-            Split<? extends ConvexSubHyperplane<P>> split;
-            ConvexSubHyperplane<P> minusBoundary;
-            ConvexSubHyperplane<P> plusBoundary;
-
-            for (final S boundary : boundaries) {
-                split = boundary.split(splitter);
-
-                minusBoundary = split.getMinus();
-                plusBoundary = split.getPlus();
-
-                if (minusBoundary != null) {
-                    minusBoundaries.add(subhpType.cast(minusBoundary));
-                }
-
-                if (plusBoundary != null) {
-                    plusBoundaries.add(subhpType.cast(plusBoundary));
-                }
-            }
+            splitBoundaries(splitter, subhpType, minusBoundaries, plusBoundaries);
 
             minusBoundaries.add(subhpType.cast(trimmedSplitter));
             plusBoundaries.add(subhpType.cast(trimmedSplitter.reverse()));
 
             return new Split<>(factory.apply(minusBoundaries), factory.apply(plusBoundaries));
+        }
+    }
+
+    /** Split the boundaries of the region by the given hyperplane, adding the split parts into the
+     * corresponding lists.
+     * @param splitter splitting hyperplane
+     * @param subhpType the type used for the boundary subhyperplanes
+     * @param minusBoundaries list that will contain the portions of the boundaries on the minus side
+     *      of the splitting hyperplane
+     * @param plusBoundaries list that will contain the portions of the boundaries on the plus side of
+     *      the splitting hyperplane
+     */
+    private void splitBoundaries(final Hyperplane<P> splitter, final Class<S> subhpType,
+            final List<S> minusBoundaries, final List<S> plusBoundaries) {
+
+        Split<? extends ConvexSubHyperplane<P>> split;
+        ConvexSubHyperplane<P> minusBoundary;
+        ConvexSubHyperplane<P> plusBoundary;
+
+        for (final S boundary : boundaries) {
+            split = boundary.split(splitter);
+
+            minusBoundary = split.getMinus();
+            plusBoundary = split.getPlus();
+
+            if (minusBoundary != null) {
+                minusBoundaries.add(subhpType.cast(minusBoundary));
+            }
+
+            if (plusBoundary != null) {
+                plusBoundaries.add(subhpType.cast(plusBoundary));
+            }
         }
     }
 

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/BoundarySource3D.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/BoundarySource3D.java
@@ -50,6 +50,6 @@ public interface BoundarySource3D extends BoundarySource<Facet> {
      * @return a boundary source containing the given boundaries
      */
     static BoundarySource3D from(final Collection<Facet> boundaries) {
-        return () -> boundaries.stream();
+        return boundaries::stream;
     }
 }

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/BoundarySourceLinecaster3D.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/BoundarySourceLinecaster3D.java
@@ -18,6 +18,7 @@ package org.apache.commons.geometry.euclidean.threed;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -65,7 +66,7 @@ final class BoundarySourceLinecaster3D implements Linecastable3D {
     private Stream<LinecastPoint3D> getIntersectionStream(final Segment3D segment) {
         return boundarySrc.boundaryStream()
                 .map(boundary -> computeIntersection(boundary, segment))
-                .filter(intersection -> intersection != null);
+                .filter(Objects::nonNull);
     }
 
     /** Compute the intersection between a boundary facet and linecast intersecting segment. Null is

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/BoundarySource2D.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/BoundarySource2D.java
@@ -50,6 +50,6 @@ public interface BoundarySource2D extends BoundarySource<Segment> {
      * @return a boundary source containing the given boundaries
      */
     static BoundarySource2D from(final Collection<Segment> boundaries) {
-        return () -> boundaries.stream();
+        return boundaries::stream;
     }
 }

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/BoundarySourceLinecaster2D.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/BoundarySourceLinecaster2D.java
@@ -18,6 +18,7 @@ package org.apache.commons.geometry.euclidean.twod;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -65,7 +66,7 @@ final class BoundarySourceLinecaster2D implements Linecastable2D {
     private Stream<LinecastPoint2D> getIntersectionStream(final Segment segment) {
         return boundarySrc.boundaryStream()
                 .map(boundary -> computeIntersection(boundary, segment))
-                .filter(intersection -> intersection != null);
+                .filter(Objects::nonNull);
     }
 
     /** Compute the intersection between a boundary segment and linecast intersecting segment. Null is


### PR DESCRIPTION
- using method references instead of lambdas
- simplifying AbstractConvexHyperplaneBoundedRegion.splitInternal