### PR TITLE
GEOMETRY-88: Reverting ConvexSubPlane to Facet name change

### DIFF
--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/BoundarySource3D.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/BoundarySource3D.java
@@ -24,7 +24,7 @@ import org.apache.commons.geometry.core.partitioning.BoundarySource;
 /** Extension of the {@link BoundarySource} interface for Euclidean 3D
  * space.
  */
-public interface BoundarySource3D extends BoundarySource<Facet> {
+public interface BoundarySource3D extends BoundarySource<ConvexSubPlane> {
 
     /** Return a BSP tree constructed from the boundaries contained in this instance.
      * The default implementation creates a new, empty tree and inserts the
@@ -42,7 +42,7 @@ public interface BoundarySource3D extends BoundarySource<Facet> {
      * @param boundaries boundaries to include in the boundary source
      * @return a boundary source containing the given boundaries
      */
-    static BoundarySource3D from(final Facet... boundaries) {
+    static BoundarySource3D from(final ConvexSubPlane... boundaries) {
         return from(Arrays.asList(boundaries));
     }
 
@@ -51,7 +51,7 @@ public interface BoundarySource3D extends BoundarySource<Facet> {
      * @param boundaries boundaries to include in the boundary source
      * @return a boundary source containing the given boundaries
      */
-    static BoundarySource3D from(final Collection<Facet> boundaries) {
+    static BoundarySource3D from(final Collection<ConvexSubPlane> boundaries) {
         return boundaries::stream;
     }
 }

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/BoundarySourceLinecaster3D.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/BoundarySourceLinecaster3D.java
@@ -69,18 +69,18 @@ final class BoundarySourceLinecaster3D implements Linecastable3D {
                 .filter(Objects::nonNull);
     }
 
-    /** Compute the intersection between a boundary facet and linecast intersecting segment. Null is
+    /** Compute the intersection between a boundary subplane and segment. Null is
      * returned if no intersection is discovered.
-     * @param facet facet from the boundary source
+     * @param subplane subplane from the boundary source
      * @param segment linecast segment to intersect with
      * @return the linecast intersection between the two arguments or null if there is no such
      *      intersection
      */
-    private LinecastPoint3D computeIntersection(final Facet facet, final Segment3D segment) {
-        final Vector3D intersectionPt = facet.intersection(segment);
+    private LinecastPoint3D computeIntersection(final ConvexSubPlane subplane, final Segment3D segment) {
+        final Vector3D intersectionPt = subplane.intersection(segment);
 
         if (intersectionPt != null) {
-            final Vector3D normal = facet.getPlane().getNormal();
+            final Vector3D normal = subplane.getPlane().getNormal();
 
             return new LinecastPoint3D(intersectionPt, normal, segment.getLine());
         }

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/ConvexSubPlane.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/ConvexSubPlane.java
@@ -33,7 +33,7 @@ import org.apache.commons.geometry.euclidean.twod.Vector2D;
 /** Class representing a convex subhyperplane in 3 dimensional Euclidean space, meaning
  * a 2D convex area embedded in a plane. The subhyperplane may be finite or infinite.
  */
-public final class Facet extends AbstractSubPlane<ConvexArea>
+public final class ConvexSubPlane extends AbstractSubPlane<ConvexArea>
     implements ConvexSubHyperplane<Vector3D>  {
     /** The embedded 2D area. */
     private final ConvexArea area;
@@ -42,7 +42,7 @@ public final class Facet extends AbstractSubPlane<ConvexArea>
      * @param plane plane the the convex area is embedded in
      * @param area the embedded convex area
      */
-    private Facet(final Plane plane, final ConvexArea area) {
+    private ConvexSubPlane(final Plane plane, final ConvexArea area) {
         super(plane);
 
         this.area = area;
@@ -50,13 +50,13 @@ public final class Facet extends AbstractSubPlane<ConvexArea>
 
     /** {@inheritDoc} */
     @Override
-    public List<Facet> toConvex() {
+    public List<ConvexSubPlane> toConvex() {
         return Arrays.asList(this);
     }
 
     /** {@inheritDoc} */
     @Override
-    public Facet reverse() {
+    public ConvexSubPlane reverse() {
         final Plane plane = getPlane();
         final Plane rPlane = plane.reverse();
 
@@ -66,12 +66,12 @@ public final class Facet extends AbstractSubPlane<ConvexArea>
         final AffineTransformMatrix2D transform =
                 AffineTransformMatrix2D.fromColumnVectors(rU, rV);
 
-        return new Facet(rPlane, area.transform(transform));
+        return new ConvexSubPlane(rPlane, area.transform(transform));
     }
 
     /** {@inheritDoc} */
     @Override
-    public Facet transform(final Transform<Vector3D> transform) {
+    public ConvexSubPlane transform(final Transform<Vector3D> transform) {
         final SubspaceTransform st = getPlane().subspaceTransform(transform);
         final ConvexArea tArea = area.transform(st.getTransform());
 
@@ -86,15 +86,15 @@ public final class Facet extends AbstractSubPlane<ConvexArea>
 
     /** {@inheritDoc} */
     @Override
-    public Split<Facet> split(final Hyperplane<Vector3D> splitter) {
-        return splitInternal(splitter, this, (p, r) -> new Facet(p, (ConvexArea) r));
+    public Split<ConvexSubPlane> split(final Hyperplane<Vector3D> splitter) {
+        return splitInternal(splitter, this, (p, r) -> new ConvexSubPlane(p, (ConvexArea) r));
     }
 
-    /** Get the unique intersection of this facet with the given line. Null is
+    /** Get the unique intersection of this subplane with the given line. Null is
      * returned if no unique intersection point exists (ie, the line and plane are
-     * parallel or coincident) or the line does not intersect the facet.
-     * @param line line to intersect with this facet
-     * @return the unique intersection point between the line and this facet
+     * parallel or coincident) or the line does not intersect the subplane.
+     * @param line line to intersect with this subplane
+     * @return the unique intersection point between the line and this subplane
      *      or null if no such point exists.
      * @see Plane#intersection(Line3D)
      */
@@ -103,12 +103,12 @@ public final class Facet extends AbstractSubPlane<ConvexArea>
         return (pt != null && contains(pt)) ? pt : null;
     }
 
-    /** Get the unique intersection of this facet with the given segment. Null
+    /** Get the unique intersection of this subplane with the given segment. Null
      * is returned if the underlying line and plane do not have a unique intersection
      * point (ie, they are parallel or coincident) or the intersection point is unique
-     * but is not contained in both the segment and facet.
+     * but is not contained in both the segment and subplane.
      * @param segment segment to intersect with
-     * @return the unique intersection point between this facet and the argument or
+     * @return the unique intersection point between this subplane and the argument or
      *      null if no such point exists.
      * @see Plane#intersection(Line3D)
      */
@@ -117,9 +117,9 @@ public final class Facet extends AbstractSubPlane<ConvexArea>
         return (pt != null && segment.contains(pt)) ? pt : null;
     }
 
-    /** Get the vertices for the facet. The vertices lie at the intersections of the
+    /** Get the vertices for the subplane. The vertices lie at the intersections of the
      * 2D area bounding lines.
-     * @return the vertices for the facets
+     * @return the vertices for the subplane
      */
     public List<Vector3D> getVertices() {
         return getPlane().toSpace(area.getVertices());
@@ -130,15 +130,15 @@ public final class Facet extends AbstractSubPlane<ConvexArea>
      * @param area area embedded in the plane
      * @return a new convex sub plane instance
      */
-    public static Facet fromConvexArea(final Plane plane, final ConvexArea area) {
-        return new Facet(plane, area);
+    public static ConvexSubPlane fromConvexArea(final Plane plane, final ConvexArea area) {
+        return new ConvexSubPlane(plane, area);
     }
 
     /** Create a new instance from the given sequence of points. The points must define a unique plane, meaning that
     * at least 3 unique vertices must be given. In contrast with the
     * {@link #fromVertices(Collection, DoublePrecisionContext)} method, the first point in the sequence is included
     * at the end if needed, in order to form a closed loop.
-    * @param pts collection of points defining the facets
+    * @param pts collection of points defining the subplane
     * @param precision precision context used to compare floating point values
     * @return a new instance defined by the given sequence of vertices
     * @throws IllegalArgumentException if fewer than 3 vertices are given or the vertices do not define a
@@ -147,14 +147,14 @@ public final class Facet extends AbstractSubPlane<ConvexArea>
     * @see #fromVertices(Collection, boolean, DoublePrecisionContext)
     * @see Plane#fromPoints(Collection, DoublePrecisionContext)
     */
-    public static Facet fromVertexLoop(final Collection<Vector3D> pts,
+    public static ConvexSubPlane fromVertexLoop(final Collection<Vector3D> pts,
             final DoublePrecisionContext precision) {
         return fromVertices(pts, true, precision);
     }
 
     /** Create a new instance from the given sequence of points. The points must define a unique plane, meaning that
      * at least 3 unique vertices must be given.
-     * @param pts collection of points defining the facet
+     * @param pts collection of points defining the subplane
      * @param precision precision context used to compare floating point values
      * @return a new instance defined by the given sequence of vertices
      * @throws IllegalArgumentException if fewer than 3 vertices are given or the vertices do not define a
@@ -163,7 +163,7 @@ public final class Facet extends AbstractSubPlane<ConvexArea>
      * @see #fromVertices(Collection, boolean, DoublePrecisionContext)
      * @see Plane#fromPoints(Collection, DoublePrecisionContext)
      */
-    public static Facet fromVertices(final Collection<Vector3D> pts,
+    public static ConvexSubPlane fromVertices(final Collection<Vector3D> pts,
             final DoublePrecisionContext precision) {
         return fromVertices(pts, false, precision);
     }
@@ -175,14 +175,14 @@ public final class Facet extends AbstractSubPlane<ConvexArea>
      * @param close if true, the point sequence will implicitly include the start point again at the end; otherwise
      *      the vertex sequence is taken as-is
      * @param precision precision context used to compare floating point values
-     * @return a new facet instance
+     * @return a new subplane instance
      * @throws IllegalArgumentException if fewer than 3 vertices are given or the vertices do not define a
      *      unique plane
      * @see #fromVertexLoop(Collection, DoublePrecisionContext)
      * @see #fromVertices(Collection, DoublePrecisionContext)
      * @see Plane#fromPoints(Collection, DoublePrecisionContext)
      */
-    public static Facet fromVertices(final Collection<Vector3D> pts, final boolean close,
+    public static ConvexSubPlane fromVertices(final Collection<Vector3D> pts, final boolean close,
             final DoublePrecisionContext precision) {
 
         final Plane plane = Plane.fromPoints(pts, precision);
@@ -190,6 +190,6 @@ public final class Facet extends AbstractSubPlane<ConvexArea>
         final List<Vector2D> subspacePts = plane.toSubspace(pts);
         final ConvexArea area = ConvexArea.fromVertices(subspacePts, close, precision);
 
-        return new Facet(plane, area);
+        return new ConvexSubPlane(plane, area);
     }
 }

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/Plane.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/Plane.java
@@ -426,8 +426,8 @@ public final class Plane extends AbstractHyperplane<Vector3D>
 
     /** {@inheritDoc} */
     @Override
-    public Facet span() {
-        return Facet.fromConvexArea(this, ConvexArea.full());
+    public ConvexSubPlane span() {
+        return ConvexSubPlane.fromConvexArea(this, ConvexArea.full());
     }
 
     /**

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/RegionBSPTree3D.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/RegionBSPTree3D.java
@@ -64,20 +64,20 @@ public final class RegionBSPTree3D extends AbstractRegionBSPTree<Vector3D, Regio
 
     /** {@inheritDoc} */
     @Override
-    public Iterable<Facet> boundaries() {
-        return createBoundaryIterable(b -> (Facet) b);
+    public Iterable<ConvexSubPlane> boundaries() {
+        return createBoundaryIterable(b -> (ConvexSubPlane) b);
     }
 
     /** {@inheritDoc} */
     @Override
-    public Stream<Facet> boundaryStream() {
+    public Stream<ConvexSubPlane> boundaryStream() {
         return StreamSupport.stream(boundaries().spliterator(), false);
     }
 
     /** {@inheritDoc} */
     @Override
-    public List<Facet> getBoundaries() {
-        return createBoundaryList(b -> (Facet) b);
+    public List<ConvexSubPlane> getBoundaries() {
+        return createBoundaryList(b -> (ConvexSubPlane) b);
     }
 
     /** Return a list of {@link ConvexVolume}s representing the same region
@@ -202,7 +202,7 @@ public final class RegionBSPTree3D extends AbstractRegionBSPTree<Vector3D, Regio
      * @return a new tree instance constructed from the given boundaries
      * @see #from(Iterable, boolean)
      */
-    public static RegionBSPTree3D from(final Iterable<Facet> boundaries) {
+    public static RegionBSPTree3D from(final Iterable<ConvexSubPlane> boundaries) {
         return from(boundaries, false);
     }
 
@@ -213,7 +213,7 @@ public final class RegionBSPTree3D extends AbstractRegionBSPTree<Vector3D, Regio
      * @param full if true, the initial tree will contain the entire space
      * @return a new tree instance constructed from the given boundaries
      */
-    public static RegionBSPTree3D from(final Iterable<Facet> boundaries, final boolean full) {
+    public static RegionBSPTree3D from(final Iterable<ConvexSubPlane> boundaries, final boolean full) {
         final RegionBSPTree3D tree = new RegionBSPTree3D(full);
         tree.insert(boundaries);
 
@@ -294,7 +294,7 @@ public final class RegionBSPTree3D extends AbstractRegionBSPTree<Vector3D, Regio
      */
     private static final class RegionSizePropertiesVisitor implements BSPTreeVisitor<Vector3D, RegionNode3D> {
 
-        /** Accumulator for facet volume contributions. */
+        /** Accumulator for boundary volume contributions. */
         private double volumeSum;
 
         /** Barycenter contribution x coordinate accumulator. */
@@ -311,8 +311,8 @@ public final class RegionBSPTree3D extends AbstractRegionBSPTree<Vector3D, Regio
         public Result visit(final RegionNode3D node) {
             if (node.isInternal()) {
                 final RegionCutBoundary<Vector3D> boundary = node.getCutBoundary();
-                addFacetContribution(boundary.getOutsideFacing(), false);
-                addFacetContribution(boundary.getInsideFacing(), true);
+                addBoundaryContribution(boundary.getOutsideFacing(), false);
+                addBoundaryContribution(boundary.getInsideFacing(), true);
             }
 
             return Result.CONTINUE;
@@ -331,7 +331,7 @@ public final class RegionBSPTree3D extends AbstractRegionBSPTree<Vector3D, Regio
                 // apply the 1/3 pyramid volume scaling factor
                 size = volumeSum / 3.0;
 
-                // Since the volume we used when adding together the facet contributions
+                // Since the volume we used when adding together the boundary contributions
                 // was 3x the actual pyramid size, we'll multiply by 1/4 here instead
                 // of 3/4 to adjust for the actual barycenter position in each pyramid.
                 final double barycenterScale = 1.0 / (4 * size);
@@ -344,12 +344,12 @@ public final class RegionBSPTree3D extends AbstractRegionBSPTree<Vector3D, Regio
             return new RegionSizeProperties<>(size, barycenter);
         }
 
-        /** Add the facet contribution of the given node cut boundary. If {@code reverse} is true,
-         * the volume of the facet contribution is reversed before being added to the total.
+        /** Add the contribution of the given node cut boundary. If {@code reverse} is true,
+         * the volume of the contribution is reversed before being added to the total.
          * @param boundary node cut boundary
-         * @param reverse if true, the facet contribution is reversed before being added to the total.
+         * @param reverse if true, the boundary contribution is reversed before being added to the total.
          */
-        private void addFacetContribution(final SubHyperplane<Vector3D> boundary, boolean reverse) {
+        private void addBoundaryContribution(final SubHyperplane<Vector3D> boundary, boolean reverse) {
             final SubPlane subplane = (SubPlane) boundary;
             final RegionBSPTree2D base = subplane.getSubspaceRegion();
 

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/SubPlane.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/SubPlane.java
@@ -66,14 +66,14 @@ public final class SubPlane extends AbstractSubPlane<RegionBSPTree2D> {
 
     /** {@inheritDoc} */
     @Override
-    public List<Facet> toConvex() {
+    public List<ConvexSubPlane> toConvex() {
         final List<ConvexArea> areas = region.toConvex();
 
         final Plane plane = getPlane();
-        final List<Facet> facets = new ArrayList<>(areas.size());
+        final List<ConvexSubPlane> facets = new ArrayList<>(areas.size());
 
         for (final ConvexArea area : areas) {
-            facets.add(Facet.fromConvexArea(plane, area));
+            facets.add(ConvexSubPlane.fromConvexArea(plane, area));
         }
 
         return facets;
@@ -112,15 +112,15 @@ public final class SubPlane extends AbstractSubPlane<RegionBSPTree2D> {
         return new SubPlane(subTransform.getPlane(), tRegion);
     }
 
-    /** Add a facet (convex subplane) to this instance.
-     * @param facet facet to add
-     * @throws IllegalArgumentException if the given facet is not from
+    /** Add a convex subplane to this instance.
+     * @param subplane convex subplane to add
+     * @throws IllegalArgumentException if the given subplane is not from
      *      a plane equivalent to this instance
      */
-    public void add(final Facet facet) {
-        validatePlane(facet.getPlane());
+    public void add(final ConvexSubPlane subplane) {
+        validatePlane(subplane.getPlane());
 
-        region.add(facet.getSubspaceRegion());
+        region.add(subplane.getSubspaceRegion());
     }
 
     /** Add a subplane to this instance.
@@ -186,8 +186,8 @@ public final class SubPlane extends AbstractSubPlane<RegionBSPTree2D> {
          * @param sub the subhyperplane to add; either convex or non-convex
          */
         private void addInternal(final SubHyperplane<Vector3D> sub) {
-            if (sub instanceof Facet) {
-                subplane.add((Facet) sub);
+            if (sub instanceof ConvexSubPlane) {
+                subplane.add((ConvexSubPlane) sub);
             } else if (sub instanceof SubPlane) {
                 subplane.add((SubPlane) sub);
             } else {

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/shapes/Parallelepiped.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/shapes/Parallelepiped.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.apache.commons.geometry.core.precision.DoublePrecisionContext;
-import org.apache.commons.geometry.euclidean.threed.Facet;
+import org.apache.commons.geometry.euclidean.threed.ConvexSubPlane;
 import org.apache.commons.geometry.euclidean.threed.Vector3D;
 
 /** Class containing utility methods for constructing parallelepipeds. Parallelepipeds
@@ -35,17 +35,17 @@ public final class Parallelepiped {
     private Parallelepiped() {
     }
 
-    /** Return a list of {@link Facet}s defining an axis-aligned parallelepiped, ie, a rectangular prism.
+    /** Return a list of {@link ConvexSubPlane}s defining an axis-aligned parallelepiped, ie, a rectangular prism.
      * The points {@code a} and {@code b} are taken to represent opposite corner points in the prism and may be
      * specified in any order.
      * @param a first corner point in the prism (opposite of {@code b})
      * @param b second corner point in the prism (opposite of {@code a})
-     * @param precision precision context used to construct facet instances
+     * @param precision precision context used to construct subplane instances
      * @return a list containing the boundaries of the rectangular prism
      * @throws IllegalArgumentException if the width, height, or depth of the defined prism is zero
      *      as evaluated by the precision context.
      */
-    public static List<Facet> axisAligned(final Vector3D a, final Vector3D b,
+    public static List<ConvexSubPlane> axisAligned(final Vector3D a, final Vector3D b,
             final DoublePrecisionContext precision) {
 
         final double minX = Math.min(a.getX(), b.getX());
@@ -75,16 +75,16 @@ public final class Parallelepiped {
 
         return Arrays.asList(
             // -z and +z sides
-            Facet.fromVertexLoop(Arrays.asList(vertices[0], vertices[3], vertices[2], vertices[1]), precision),
-            Facet.fromVertexLoop(Arrays.asList(vertices[4], vertices[5], vertices[6], vertices[7]), precision),
+            ConvexSubPlane.fromVertexLoop(Arrays.asList(vertices[0], vertices[3], vertices[2], vertices[1]), precision),
+            ConvexSubPlane.fromVertexLoop(Arrays.asList(vertices[4], vertices[5], vertices[6], vertices[7]), precision),
 
             // -x and +x sides
-            Facet.fromVertexLoop(Arrays.asList(vertices[0], vertices[4], vertices[7], vertices[3]), precision),
-            Facet.fromVertexLoop(Arrays.asList(vertices[5], vertices[1], vertices[2], vertices[6]), precision),
+            ConvexSubPlane.fromVertexLoop(Arrays.asList(vertices[0], vertices[4], vertices[7], vertices[3]), precision),
+            ConvexSubPlane.fromVertexLoop(Arrays.asList(vertices[5], vertices[1], vertices[2], vertices[6]), precision),
 
             // -y and +y sides
-            Facet.fromVertexLoop(Arrays.asList(vertices[0], vertices[1], vertices[5], vertices[4]), precision),
-            Facet.fromVertexLoop(Arrays.asList(vertices[3], vertices[7], vertices[6], vertices[2]), precision)
+            ConvexSubPlane.fromVertexLoop(Arrays.asList(vertices[0], vertices[1], vertices[5], vertices[4]), precision),
+            ConvexSubPlane.fromVertexLoop(Arrays.asList(vertices[3], vertices[7], vertices[6], vertices[2]), precision)
         );
     }
 }

--- a/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/DocumentationExamplesTest.java
+++ b/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/DocumentationExamplesTest.java
@@ -29,7 +29,7 @@ import org.apache.commons.geometry.euclidean.oned.Interval;
 import org.apache.commons.geometry.euclidean.oned.RegionBSPTree1D;
 import org.apache.commons.geometry.euclidean.oned.Vector1D;
 import org.apache.commons.geometry.euclidean.threed.AffineTransformMatrix3D;
-import org.apache.commons.geometry.euclidean.threed.Facet;
+import org.apache.commons.geometry.euclidean.threed.ConvexSubPlane;
 import org.apache.commons.geometry.euclidean.threed.Line3D;
 import org.apache.commons.geometry.euclidean.threed.LinecastPoint3D;
 import org.apache.commons.geometry.euclidean.threed.Plane;
@@ -415,10 +415,10 @@ public class DocumentationExamplesTest {
             {b1, b2, b3, b4}
         };
 
-        // convert the vertices to facets and insert into a bsp tree
+        // convert the vertices to convex subplanes and insert into a bsp tree
         RegionBSPTree3D tree = RegionBSPTree3D.empty();
         Arrays.stream(faceIndices)
-            .map(vertices -> Facet.fromVertexLoop(Arrays.asList(vertices), precision))
+            .map(vertices -> ConvexSubPlane.fromVertexLoop(Arrays.asList(vertices), precision))
             .forEach(tree::insert);
 
         // split the region through its barycenter along a diagonal of the base
@@ -426,15 +426,15 @@ public class DocumentationExamplesTest {
         Split<RegionBSPTree3D> split = tree.split(cutter);
 
         // compute some properties for the minus side of the split and convert back to subhyperplanes
-        // (ie, facets)
+        // (ie, boundary facets)
         RegionBSPTree3D minus = split.getMinus();
 
         double minusSize = minus.getSize(); // 1/6
-        List<Facet> minusFacets = minus.getBoundaries(); // size = 4
+        List<ConvexSubPlane> minusBoundaries = minus.getBoundaries(); // size = 4
 
         // ---------------------
         Assert.assertEquals(1.0 / 6.0, minusSize, TEST_EPS);
-        Assert.assertEquals(4, minusFacets.size());
+        Assert.assertEquals(4, minusBoundaries.size());
     }
 
     @Test

--- a/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/threed/BoundarySource3DTest.java
+++ b/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/threed/BoundarySource3DTest.java
@@ -36,9 +36,9 @@ public class BoundarySource3DTest {
     @Test
     public void testToTree() {
         // act
-        Facet a = Facet.fromVertexLoop(
+        ConvexSubPlane a = ConvexSubPlane.fromVertexLoop(
                 Arrays.asList(Vector3D.ZERO, Vector3D.Unit.PLUS_X, Vector3D.Unit.PLUS_Y), TEST_PRECISION);
-        Facet b = Facet.fromVertexLoop(
+        ConvexSubPlane b = ConvexSubPlane.fromVertexLoop(
                 Arrays.asList(Vector3D.ZERO, Vector3D.Unit.PLUS_Y, Vector3D.Unit.MINUS_Z), TEST_PRECISION);
 
         BoundarySource3D src = BoundarySource3D.from(a, b);
@@ -72,22 +72,22 @@ public class BoundarySource3DTest {
         BoundarySource3D src = BoundarySource3D.from();
 
         // assert
-        List<Facet> segments = src.boundaryStream().collect(Collectors.toList());
+        List<ConvexSubPlane> segments = src.boundaryStream().collect(Collectors.toList());
         Assert.assertEquals(0, segments.size());
     }
 
     @Test
     public void testFrom_varargs() {
         // act
-        Facet a = Facet.fromVertexLoop(
+        ConvexSubPlane a = ConvexSubPlane.fromVertexLoop(
                 Arrays.asList(Vector3D.ZERO, Vector3D.Unit.PLUS_X, Vector3D.Unit.PLUS_Y), TEST_PRECISION);
-        Facet b = Facet.fromVertexLoop(
+        ConvexSubPlane b = ConvexSubPlane.fromVertexLoop(
                 Arrays.asList(Vector3D.ZERO, Vector3D.Unit.PLUS_Y, Vector3D.Unit.MINUS_Z), TEST_PRECISION);
 
         BoundarySource3D src = BoundarySource3D.from(a, b);
 
         // assert
-        List<Facet> boundaries = src.boundaryStream().collect(Collectors.toList());
+        List<ConvexSubPlane> boundaries = src.boundaryStream().collect(Collectors.toList());
         Assert.assertEquals(2, boundaries.size());
 
         Assert.assertSame(a, boundaries.get(0));
@@ -97,32 +97,32 @@ public class BoundarySource3DTest {
     @Test
     public void testFrom_list_empty() {
         // arrange
-        List<Facet> input = new ArrayList<>();
+        List<ConvexSubPlane> input = new ArrayList<>();
 
         // act
         BoundarySource3D src = BoundarySource3D.from(input);
 
         // assert
-        List<Facet> segments = src.boundaryStream().collect(Collectors.toList());
+        List<ConvexSubPlane> segments = src.boundaryStream().collect(Collectors.toList());
         Assert.assertEquals(0, segments.size());
     }
 
     @Test
     public void testFrom_list() {
         // act
-        Facet a = Facet.fromVertexLoop(
+        ConvexSubPlane a = ConvexSubPlane.fromVertexLoop(
                 Arrays.asList(Vector3D.ZERO, Vector3D.Unit.PLUS_X, Vector3D.Unit.PLUS_Y), TEST_PRECISION);
-        Facet b = Facet.fromVertexLoop(
+        ConvexSubPlane b = ConvexSubPlane.fromVertexLoop(
                 Arrays.asList(Vector3D.ZERO, Vector3D.Unit.PLUS_Y, Vector3D.Unit.MINUS_Z), TEST_PRECISION);
 
-        List<Facet> input = new ArrayList<>();
+        List<ConvexSubPlane> input = new ArrayList<>();
         input.add(a);
         input.add(b);
 
         BoundarySource3D src = BoundarySource3D.from(input);
 
         // assert
-        List<Facet> segments = src.boundaryStream().collect(Collectors.toList());
+        List<ConvexSubPlane> segments = src.boundaryStream().collect(Collectors.toList());
         Assert.assertEquals(2, segments.size());
 
         Assert.assertSame(a, segments.get(0));

--- a/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/threed/BoundarySourceLinecaster3DTest.java
+++ b/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/threed/BoundarySourceLinecaster3DTest.java
@@ -100,8 +100,8 @@ public class BoundarySourceLinecaster3DTest {
     public void testLinecast_line_removesDuplicatePoints() {
         // arrange
         BoundarySource3D src = BoundarySource3D.from(
-                    Facet.fromVertexLoop(Arrays.asList(Vector3D.ZERO, Vector3D.Unit.PLUS_X, Vector3D.Unit.PLUS_Y), TEST_PRECISION),
-                    Facet.fromVertexLoop(Arrays.asList(Vector3D.ZERO, Vector3D.Unit.PLUS_Y, Vector3D.Unit.MINUS_X), TEST_PRECISION)
+                    ConvexSubPlane.fromVertexLoop(Arrays.asList(Vector3D.ZERO, Vector3D.Unit.PLUS_X, Vector3D.Unit.PLUS_Y), TEST_PRECISION),
+                    ConvexSubPlane.fromVertexLoop(Arrays.asList(Vector3D.ZERO, Vector3D.Unit.PLUS_Y, Vector3D.Unit.MINUS_X), TEST_PRECISION)
                 );
         BoundarySourceLinecaster3D linecaster = new BoundarySourceLinecaster3D(src);
 
@@ -233,8 +233,8 @@ public class BoundarySourceLinecaster3DTest {
     public void testLinecast_segment_removesDuplicatePoints() {
         // arrange
         BoundarySource3D src = BoundarySource3D.from(
-                    Facet.fromVertexLoop(Arrays.asList(Vector3D.ZERO, Vector3D.Unit.PLUS_X, Vector3D.Unit.PLUS_Y), TEST_PRECISION),
-                    Facet.fromVertexLoop(Arrays.asList(Vector3D.ZERO, Vector3D.Unit.PLUS_Y, Vector3D.Unit.MINUS_X), TEST_PRECISION)
+                    ConvexSubPlane.fromVertexLoop(Arrays.asList(Vector3D.ZERO, Vector3D.Unit.PLUS_X, Vector3D.Unit.PLUS_Y), TEST_PRECISION),
+                    ConvexSubPlane.fromVertexLoop(Arrays.asList(Vector3D.ZERO, Vector3D.Unit.PLUS_Y, Vector3D.Unit.MINUS_X), TEST_PRECISION)
                 );
         BoundarySourceLinecaster3D linecaster = new BoundarySourceLinecaster3D(src);
 

--- a/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/threed/ConvexSubPlaneTest.java
+++ b/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/threed/ConvexSubPlaneTest.java
@@ -35,7 +35,7 @@ import org.apache.commons.numbers.angle.PlaneAngleRadians;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class FacetTest {
+public class ConvexSubPlaneTest {
 
     private static final double TEST_EPS = 1e-10;
 
@@ -55,7 +55,7 @@ public class FacetTest {
                 ), TEST_PRECISION);
 
         // act
-        Facet sp = Facet.fromConvexArea(plane, area);
+        ConvexSubPlane sp = ConvexSubPlane.fromConvexArea(plane, area);
 
         // assert
         Assert.assertFalse(sp.isFull());
@@ -72,7 +72,7 @@ public class FacetTest {
     @Test
     public void testFromVertices_infinite() {
         // act
-        Facet sp = Facet.fromVertices(Arrays.asList(
+        ConvexSubPlane sp = ConvexSubPlane.fromVertices(Arrays.asList(
                     Vector3D.of(1, 0, 0),
                     Vector3D.of(1, 1, 0),
                     Vector3D.of(1, 1, 1)
@@ -112,7 +112,7 @@ public class FacetTest {
     @Test
     public void testFromVertices_finite() {
         // act
-        Facet sp = Facet.fromVertices(Arrays.asList(
+        ConvexSubPlane sp = ConvexSubPlane.fromVertices(Arrays.asList(
                     Vector3D.of(1, 0, 0),
                     Vector3D.of(1, 1, 0),
                     Vector3D.of(1, 1, 2),
@@ -153,7 +153,7 @@ public class FacetTest {
     @Test
     public void testFromVertexLoop() {
         // act
-        Facet sp = Facet.fromVertexLoop(Arrays.asList(
+        ConvexSubPlane sp = ConvexSubPlane.fromVertexLoop(Arrays.asList(
                     Vector3D.of(1, 0, 0),
                     Vector3D.of(1, 1, 0),
                     Vector3D.of(1, 1, 2)
@@ -193,11 +193,11 @@ public class FacetTest {
     @Test
     public void testToConvex() {
         // arrange
-        Facet sp = Facet.fromVertexLoop(
+        ConvexSubPlane sp = ConvexSubPlane.fromVertexLoop(
                 Arrays.asList(Vector3D.Unit.PLUS_X,  Vector3D.Unit.PLUS_Y, Vector3D.Unit.PLUS_Z), TEST_PRECISION);
 
         // act
-        List<Facet> convex = sp.toConvex();
+        List<ConvexSubPlane> convex = sp.toConvex();
 
         // assert
         Assert.assertEquals(1, convex.size());
@@ -208,7 +208,7 @@ public class FacetTest {
     public void testGetVertices_full() {
         // arrange
         Plane plane = Plane.fromNormal(Vector3D.Unit.PLUS_Z, TEST_PRECISION);
-        Facet sp = Facet.fromConvexArea(plane, ConvexArea.full());
+        ConvexSubPlane sp = ConvexSubPlane.fromConvexArea(plane, ConvexArea.full());
 
         // act
         List<Vector3D> vertices = sp.getVertices();
@@ -221,7 +221,7 @@ public class FacetTest {
     public void testGetVertices_twoParallelLines() {
         // arrange
         Plane plane = Plane.fromNormal(Vector3D.Unit.PLUS_Z, TEST_PRECISION);
-        Facet sp = Facet.fromConvexArea(plane, ConvexArea.fromBounds(
+        ConvexSubPlane sp = ConvexSubPlane.fromConvexArea(plane, ConvexArea.fromBounds(
                     Line.fromPointAndAngle(Vector2D.of(0, 1), PlaneAngleRadians.PI, TEST_PRECISION),
                     Line.fromPointAndAngle(Vector2D.of(0, -1), 0.0, TEST_PRECISION)
                 ));
@@ -237,7 +237,7 @@ public class FacetTest {
     public void testGetVertices_infiniteWithVertices() {
         // arrange
         Plane plane = Plane.fromPointAndPlaneVectors(Vector3D.of(0, 0, 1), Vector3D.Unit.PLUS_X, Vector3D.Unit.PLUS_Y, TEST_PRECISION);
-        Facet sp = Facet.fromConvexArea(plane, ConvexArea.fromBounds(
+        ConvexSubPlane sp = ConvexSubPlane.fromConvexArea(plane, ConvexArea.fromBounds(
                     Line.fromPointAndAngle(Vector2D.of(0, 1), PlaneAngleRadians.PI, TEST_PRECISION),
                     Line.fromPointAndAngle(Vector2D.of(0, -1), 0.0, TEST_PRECISION),
                     Line.fromPointAndAngle(Vector2D.of(1, 0), PlaneAngleRadians.PI_OVER_TWO, TEST_PRECISION)
@@ -257,7 +257,7 @@ public class FacetTest {
     public void testGetVertices_finite() {
         // arrange
         Plane plane = Plane.fromPointAndPlaneVectors(Vector3D.of(0, 0, 1), Vector3D.Unit.PLUS_X, Vector3D.Unit.PLUS_Y, TEST_PRECISION);
-        Facet sp = Facet.fromConvexArea(plane, ConvexArea.fromVertexLoop(Arrays.asList(
+        ConvexSubPlane sp = ConvexSubPlane.fromConvexArea(plane, ConvexArea.fromVertexLoop(Arrays.asList(
                     Vector2D.ZERO,
                     Vector2D.Unit.PLUS_X,
                     Vector2D.Unit.PLUS_Y
@@ -282,10 +282,10 @@ public class FacetTest {
         Vector3D p2 = Vector3D.of(2, 0, 1);
         Vector3D p3 = Vector3D.of(1, 1, 1);
 
-        Facet sp = Facet.fromVertexLoop(Arrays.asList(p1, p2, p3), TEST_PRECISION);
+        ConvexSubPlane sp = ConvexSubPlane.fromVertexLoop(Arrays.asList(p1, p2, p3), TEST_PRECISION);
 
         // act
-        Facet reversed = sp.reverse();
+        ConvexSubPlane reversed = sp.reverse();
 
         // assert
         Assert.assertEquals(sp.getPlane().reverse(), reversed.getPlane());
@@ -304,14 +304,14 @@ public class FacetTest {
     public void testTransform_full() {
         // arrange
         Plane plane = Plane.fromPointAndPlaneVectors(Vector3D.Unit.PLUS_Z, Vector3D.Unit.PLUS_X, Vector3D.Unit.PLUS_Y, TEST_PRECISION);
-        Facet sp = Facet.fromConvexArea(plane, ConvexArea.full());
+        ConvexSubPlane sp = ConvexSubPlane.fromConvexArea(plane, ConvexArea.full());
 
         AffineTransformMatrix3D transform = AffineTransformMatrix3D.identity()
                 .rotate(QuaternionRotation.fromAxisAngle(Vector3D.Unit.PLUS_X, PlaneAngleRadians.PI_OVER_TWO))
                 .translate(Vector3D.Unit.PLUS_Y);
 
         // act
-        Facet transformed = sp.transform(transform);
+        ConvexSubPlane transformed = sp.transform(transform);
 
         // assert
         Assert.assertTrue(transformed.isFull());
@@ -324,14 +324,14 @@ public class FacetTest {
     public void testTransform_halfSpace() {
         // arrange
         Plane plane = Plane.fromPointAndPlaneVectors(Vector3D.Unit.PLUS_Z, Vector3D.Unit.PLUS_X, Vector3D.Unit.PLUS_Y, TEST_PRECISION);
-        Facet sp = Facet.fromConvexArea(plane,
+        ConvexSubPlane sp = ConvexSubPlane.fromConvexArea(plane,
                 ConvexArea.fromBounds(Line.fromPoints(Vector2D.of(1, 0), Vector2D.of(1, 1), TEST_PRECISION)));
 
         AffineTransformMatrix3D transform = AffineTransformMatrix3D.createRotation(Vector3D.Unit.PLUS_Z,
                 QuaternionRotation.fromAxisAngle(Vector3D.Unit.PLUS_Y, PlaneAngleRadians.PI_OVER_TWO));
 
         // act
-        Facet transformed = sp.transform(transform);
+        ConvexSubPlane transformed = sp.transform(transform);
 
         // assert
         Assert.assertFalse(transformed.isFull());
@@ -343,14 +343,14 @@ public class FacetTest {
     @Test
     public void testTransform_finite() {
         // arrange
-        Facet sp = Facet.fromVertexLoop(
+        ConvexSubPlane sp = ConvexSubPlane.fromVertexLoop(
                 Arrays.asList(Vector3D.of(1, 0, 0), Vector3D.of(0, 1, 0), Vector3D.of(0, 0, 1)), TEST_PRECISION);
 
         Transform<Vector3D> transform = AffineTransformMatrix3D.createScale(2)
                 .rotate(QuaternionRotation.fromAxisAngle(Vector3D.Unit.PLUS_Y, PlaneAngleRadians.PI_OVER_TWO));
 
         // act
-        Facet transformed = sp.transform(transform);
+        ConvexSubPlane transformed = sp.transform(transform);
 
         // assert
         Vector3D midpt = Vector3D.of(2, 2, -2).multiply(1 / 3.0);
@@ -368,13 +368,13 @@ public class FacetTest {
     @Test
     public void testTransform_reflection() {
         // arrange
-        Facet sp = Facet.fromVertexLoop(
+        ConvexSubPlane sp = ConvexSubPlane.fromVertexLoop(
                 Arrays.asList(Vector3D.of(1, 0, 0), Vector3D.of(0, 1, 0), Vector3D.of(0, 0, 1)), TEST_PRECISION);
 
         Transform<Vector3D> transform = AffineTransformMatrix3D.createScale(-1, 1, 1);
 
         // act
-        Facet transformed = sp.transform(transform);
+        ConvexSubPlane transformed = sp.transform(transform);
 
         // assert
         Vector3D midpt = Vector3D.of(-1, 1, 1).multiply(1 / 3.0);
@@ -393,23 +393,23 @@ public class FacetTest {
     public void testSplit_full() {
         // arrange
         Plane plane = Plane.fromPointAndNormal(Vector3D.ZERO, Vector3D.Unit.PLUS_Z, TEST_PRECISION);
-        Facet sp = Facet.fromConvexArea(plane, ConvexArea.full());
+        ConvexSubPlane sp = ConvexSubPlane.fromConvexArea(plane, ConvexArea.full());
 
         Plane splitter = Plane.fromPointAndNormal(Vector3D.ZERO, Vector3D.Unit.PLUS_X, TEST_PRECISION);
 
         // act
-        Split<Facet> split = sp.split(splitter);
+        Split<ConvexSubPlane> split = sp.split(splitter);
 
         // assert
         Assert.assertEquals(SplitLocation.BOTH, split.getLocation());
 
-        Facet minus = split.getMinus();
+        ConvexSubPlane minus = split.getMinus();
         Assert.assertEquals(1, minus.getSubspaceRegion().getBoundaries().size());
         checkPoints(minus, RegionLocation.BOUNDARY, Vector3D.ZERO, Vector3D.Unit.PLUS_Y, Vector3D.Unit.MINUS_Y);
         checkPoints(minus, RegionLocation.INSIDE, Vector3D.Unit.MINUS_X);
         checkPoints(minus, RegionLocation.OUTSIDE, Vector3D.Unit.PLUS_X);
 
-        Facet plus = split.getPlus();
+        ConvexSubPlane plus = split.getPlus();
         Assert.assertEquals(1, plus.getSubspaceRegion().getBoundaries().size());
         checkPoints(plus, RegionLocation.BOUNDARY, Vector3D.ZERO, Vector3D.Unit.PLUS_Y, Vector3D.Unit.MINUS_Y);
         checkPoints(plus, RegionLocation.INSIDE, Vector3D.Unit.PLUS_X);
@@ -419,62 +419,62 @@ public class FacetTest {
     @Test
     public void testSplit_both() {
         // arrange
-        Facet sp = Facet.fromVertexLoop(Arrays.asList(
+        ConvexSubPlane sp = ConvexSubPlane.fromVertexLoop(Arrays.asList(
                     Vector3D.of(1, 1, 1), Vector3D.of(1, 1, -3), Vector3D.of(0, 2, 0)
                 ), TEST_PRECISION);
 
         Plane splitter = Plane.fromPointAndNormal(Vector3D.ZERO, Vector3D.Unit.PLUS_Z, TEST_PRECISION);
 
         // act
-        Split<Facet> split = sp.split(splitter);
+        Split<ConvexSubPlane> split = sp.split(splitter);
 
         // assert
         Assert.assertEquals(SplitLocation.BOTH, split.getLocation());
 
-        Facet minus = split.getMinus();
+        ConvexSubPlane minus = split.getMinus();
         checkVertices(minus, Vector3D.of(1, 1, 0), Vector3D.of(1, 1, -3), Vector3D.of(0, 2, 0), Vector3D.of(1, 1, 0));
 
-        Facet plus = split.getPlus();
+        ConvexSubPlane plus = split.getPlus();
         checkVertices(plus, Vector3D.of(1, 1, 1), Vector3D.of(1, 1, 0), Vector3D.of(0, 2, 0), Vector3D.of(1, 1, 1));
     }
 
     @Test
     public void testSplit_plusOnly() {
         // arrange
-        Facet sp = Facet.fromVertexLoop(Arrays.asList(
+        ConvexSubPlane sp = ConvexSubPlane.fromVertexLoop(Arrays.asList(
                     Vector3D.of(1, 1, 1), Vector3D.of(1, 1, -3), Vector3D.of(0, 2, 0)
                 ), TEST_PRECISION);
 
         Plane splitter = Plane.fromPointAndNormal(Vector3D.of(0, 0, -3.1), Vector3D.Unit.PLUS_Z, TEST_PRECISION);
 
         // act
-        Split<Facet> split = sp.split(splitter);
+        Split<ConvexSubPlane> split = sp.split(splitter);
 
         // assert
         Assert.assertEquals(SplitLocation.PLUS, split.getLocation());
 
         Assert.assertNull(split.getMinus());
 
-        Facet plus = split.getPlus();
+        ConvexSubPlane plus = split.getPlus();
         checkVertices(plus, Vector3D.of(1, 1, 1), Vector3D.of(1, 1, -3), Vector3D.of(0, 2, 0), Vector3D.of(1, 1, 1));
     }
 
     @Test
     public void testSplit_minusOnly() {
         // arrange
-        Facet sp = Facet.fromVertexLoop(Arrays.asList(
+        ConvexSubPlane sp = ConvexSubPlane.fromVertexLoop(Arrays.asList(
                     Vector3D.of(1, 1, 1), Vector3D.of(1, 1, -3), Vector3D.of(0, 2, 0)
                 ), TEST_PRECISION);
 
         Plane splitter = Plane.fromPointAndNormal(Vector3D.of(0, 0, 1.1), Vector3D.Unit.PLUS_Z, TEST_PRECISION);
 
         // act
-        Split<Facet> split = sp.split(splitter);
+        Split<ConvexSubPlane> split = sp.split(splitter);
 
         // assert
         Assert.assertEquals(SplitLocation.MINUS, split.getLocation());
 
-        Facet minus = split.getMinus();
+        ConvexSubPlane minus = split.getMinus();
         checkVertices(minus, Vector3D.of(1, 1, 1), Vector3D.of(1, 1, -3), Vector3D.of(0, 2, 0), Vector3D.of(1, 1, 1));
 
         Assert.assertNull(split.getPlus());
@@ -483,14 +483,14 @@ public class FacetTest {
     @Test
     public void testSplit_parallelSplitter_on() {
         // arrange
-        Facet sp = Facet.fromVertexLoop(Arrays.asList(
+        ConvexSubPlane sp = ConvexSubPlane.fromVertexLoop(Arrays.asList(
                     Vector3D.of(1, 1, 1), Vector3D.of(1, 1, -3), Vector3D.of(0, 2, 0)
                 ), TEST_PRECISION);
 
         Plane splitter = sp.getPlane();
 
         // act
-        Split<Facet> split = sp.split(splitter);
+        Split<ConvexSubPlane> split = sp.split(splitter);
 
         // assert
         Assert.assertEquals(SplitLocation.NEITHER, split.getLocation());
@@ -502,7 +502,7 @@ public class FacetTest {
     @Test
     public void testSplit_parallelSplitter_minus() {
         // arrange
-        Facet sp = Facet.fromVertexLoop(Arrays.asList(
+        ConvexSubPlane sp = ConvexSubPlane.fromVertexLoop(Arrays.asList(
                     Vector3D.of(1, 1, 1), Vector3D.of(1, 1, -3), Vector3D.of(0, 2, 0)
                 ), TEST_PRECISION);
 
@@ -510,7 +510,7 @@ public class FacetTest {
         Plane splitter = plane.translate(plane.getNormal());
 
         // act
-        Split<Facet> split = sp.split(splitter);
+        Split<ConvexSubPlane> split = sp.split(splitter);
 
         // assert
         Assert.assertEquals(SplitLocation.MINUS, split.getLocation());
@@ -522,7 +522,7 @@ public class FacetTest {
     @Test
     public void testSplit_parallelSplitter_plus() {
         // arrange
-        Facet sp = Facet.fromVertexLoop(Arrays.asList(
+        ConvexSubPlane sp = ConvexSubPlane.fromVertexLoop(Arrays.asList(
                     Vector3D.of(1, 1, 1), Vector3D.of(1, 1, -3), Vector3D.of(0, 2, 0)
                 ), TEST_PRECISION);
 
@@ -530,7 +530,7 @@ public class FacetTest {
         Plane splitter = plane.translate(plane.getNormal().negate());
 
         // act
-        Split<Facet> split = sp.split(splitter);
+        Split<ConvexSubPlane> split = sp.split(splitter);
 
         // assert
         Assert.assertEquals(SplitLocation.PLUS, split.getLocation());
@@ -542,14 +542,14 @@ public class FacetTest {
     @Test
     public void testSplit_antiParallelSplitter_on() {
         // arrange
-        Facet sp = Facet.fromVertexLoop(Arrays.asList(
+        ConvexSubPlane sp = ConvexSubPlane.fromVertexLoop(Arrays.asList(
                     Vector3D.of(1, 1, 1), Vector3D.of(1, 1, -3), Vector3D.of(0, 2, 0)
                 ), TEST_PRECISION);
 
         Plane splitter = sp.getPlane().reverse();
 
         // act
-        Split<Facet> split = sp.split(splitter);
+        Split<ConvexSubPlane> split = sp.split(splitter);
 
         // assert
         Assert.assertEquals(SplitLocation.NEITHER, split.getLocation());
@@ -561,7 +561,7 @@ public class FacetTest {
     @Test
     public void testSplit_antiParallelSplitter_minus() {
         // arrange
-        Facet sp = Facet.fromVertexLoop(Arrays.asList(
+        ConvexSubPlane sp = ConvexSubPlane.fromVertexLoop(Arrays.asList(
                     Vector3D.of(1, 1, 1), Vector3D.of(1, 1, -3), Vector3D.of(0, 2, 0)
                 ), TEST_PRECISION);
 
@@ -569,7 +569,7 @@ public class FacetTest {
         Plane splitter = plane.translate(plane.getNormal());
 
         // act
-        Split<Facet> split = sp.split(splitter);
+        Split<ConvexSubPlane> split = sp.split(splitter);
 
         // assert
         Assert.assertEquals(SplitLocation.MINUS, split.getLocation());
@@ -581,7 +581,7 @@ public class FacetTest {
     @Test
     public void testSplit_antiParallelSplitter_plus() {
         // arrange
-        Facet sp = Facet.fromVertexLoop(Arrays.asList(
+        ConvexSubPlane sp = ConvexSubPlane.fromVertexLoop(Arrays.asList(
                     Vector3D.of(1, 1, 1), Vector3D.of(1, 1, -3), Vector3D.of(0, 2, 0)
                 ), TEST_PRECISION);
 
@@ -589,7 +589,7 @@ public class FacetTest {
         Plane splitter = plane.translate(plane.getNormal().negate());
 
         // act
-        Split<Facet> split = sp.split(splitter);
+        Split<ConvexSubPlane> split = sp.split(splitter);
 
         // assert
         Assert.assertEquals(SplitLocation.PLUS, split.getLocation());
@@ -601,7 +601,7 @@ public class FacetTest {
     @Test
     public void testIntersection_line() {
         // arrange
-        Facet sp = Facet.fromVertexLoop(Arrays.asList(
+        ConvexSubPlane sp = ConvexSubPlane.fromVertexLoop(Arrays.asList(
                 Vector3D.of(0, 0, 2), Vector3D.of(1, 0, 2), Vector3D.of(1, 1, 2), Vector3D.of(0, 1, 2)),
                 TEST_PRECISION);
 
@@ -621,7 +621,7 @@ public class FacetTest {
     @Test
     public void testIntersection_segment() {
         // arrange
-        Facet sp = Facet.fromVertexLoop(Arrays.asList(
+        ConvexSubPlane sp = ConvexSubPlane.fromVertexLoop(Arrays.asList(
                 Vector3D.of(0, 0, 2), Vector3D.of(1, 0, 2), Vector3D.of(1, 1, 2), Vector3D.of(0, 1, 2)),
                 TEST_PRECISION);
 
@@ -643,7 +643,7 @@ public class FacetTest {
     @Test
     public void testToString() {
         // arrange
-        Facet sp = Facet.fromVertexLoop(Arrays.asList(
+        ConvexSubPlane sp = ConvexSubPlane.fromVertexLoop(Arrays.asList(
                     Vector3D.ZERO,
                     Vector3D.Unit.PLUS_X,
                     Vector3D.Unit.PLUS_Y
@@ -682,13 +682,13 @@ public class FacetTest {
         EuclideanTestUtils.assertCoordinatesEqual(origin, plane.getNormal().multiply(-offset), TEST_EPS);
     }
 
-    private static void checkPoints(Facet sp, RegionLocation loc, Vector3D... pts) {
+    private static void checkPoints(ConvexSubPlane sp, RegionLocation loc, Vector3D... pts) {
         for (Vector3D pt : pts) {
             Assert.assertEquals("Unexpected location for point " + pt, loc, sp.classify(pt));
         }
     }
 
-    private static void checkVertices(Facet sp, Vector3D... pts) {
+    private static void checkVertices(ConvexSubPlane sp, Vector3D... pts) {
         List<Vector3D> actual = sp.getPlane().toSpace(
                 sp.getSubspaceRegion().getBoundaryPaths().get(0).getVertices());
 

--- a/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/threed/ConvexVolumeTest.java
+++ b/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/threed/ConvexVolumeTest.java
@@ -62,12 +62,12 @@ public class ConvexVolumeTest {
         ConvexVolume volume = ConvexVolume.fromBounds(plane);
 
         // act
-        List<Facet> boundaries = volume.boundaryStream().collect(Collectors.toList());
+        List<ConvexSubPlane> boundaries = volume.boundaryStream().collect(Collectors.toList());
 
         // assert
         Assert.assertEquals(1, boundaries.size());
 
-        Facet sp = boundaries.get(0);
+        ConvexSubPlane sp = boundaries.get(0);
         Assert.assertEquals(0, sp.getSubspaceRegion().getBoundaries().size());
         Assert.assertSame(plane, sp.getPlane());
     }
@@ -78,7 +78,7 @@ public class ConvexVolumeTest {
         ConvexVolume volume = ConvexVolume.full();
 
         // act
-        List<Facet> boundaries = volume.boundaryStream().collect(Collectors.toList());
+        List<ConvexSubPlane> boundaries = volume.boundaryStream().collect(Collectors.toList());
 
         // assert
         Assert.assertEquals(0, boundaries.size());
@@ -186,11 +186,11 @@ public class ConvexVolumeTest {
         // arrange
         ConvexVolume vol = rect(Vector3D.ZERO, 0.5, 0.5, 0.5);
 
-        Facet subplane = Facet.fromConvexArea(
+        ConvexSubPlane subplane = ConvexSubPlane.fromConvexArea(
                 Plane.fromNormal(Vector3D.Unit.PLUS_X, TEST_PRECISION), ConvexArea.full());
 
         // act
-        Facet trimmed = vol.trim(subplane);
+        ConvexSubPlane trimmed = vol.trim(subplane);
 
         // assert
         Assert.assertEquals(1, trimmed.getSize(), TEST_EPS);

--- a/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/threed/PlaneTest.java
+++ b/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/threed/PlaneTest.java
@@ -948,7 +948,7 @@ public class PlaneTest {
         Plane plane = Plane.fromPointAndNormal(Vector3D.ZERO, Vector3D.Unit.PLUS_Z, TEST_PRECISION);
 
         // act
-        Facet sub = plane.span();
+        ConvexSubPlane sub = plane.span();
 
         // assert
         Assert.assertSame(plane, sub.getPlane());

--- a/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/threed/RegionBSPTree3DTest.java
+++ b/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/threed/RegionBSPTree3DTest.java
@@ -130,7 +130,7 @@ public class RegionBSPTree3DTest {
         RegionBSPTree3D tree = createRect(Vector3D.ZERO, Vector3D.of(1, 1, 1));
 
         // act
-        List<Facet> facets = new ArrayList<>();
+        List<ConvexSubPlane> facets = new ArrayList<>();
         tree.boundaries().forEach(facets::add);
 
         // assert
@@ -143,7 +143,7 @@ public class RegionBSPTree3DTest {
         RegionBSPTree3D tree = createRect(Vector3D.ZERO, Vector3D.of(1, 1, 1));
 
         // act
-        List<Facet> facets = tree.getBoundaries();
+        List<ConvexSubPlane> facets = tree.getBoundaries();
 
         // assert
         Assert.assertEquals(6, facets.size());
@@ -155,7 +155,7 @@ public class RegionBSPTree3DTest {
         RegionBSPTree3D tree = createRect(Vector3D.ZERO, Vector3D.of(1, 1, 1));
 
         // act
-        List<Facet> facets = tree.boundaryStream().collect(Collectors.toList());
+        List<ConvexSubPlane> facets = tree.boundaryStream().collect(Collectors.toList());
 
         // assert
         Assert.assertEquals(6, facets.size());
@@ -167,7 +167,7 @@ public class RegionBSPTree3DTest {
         RegionBSPTree3D tree = RegionBSPTree3D.full();
 
         // act
-        List<Facet> facets = tree.boundaryStream().collect(Collectors.toList());
+        List<ConvexSubPlane> facets = tree.boundaryStream().collect(Collectors.toList());
 
         // assert
         Assert.assertEquals(0, facets.size());
@@ -261,9 +261,9 @@ public class RegionBSPTree3DTest {
     public void testFrom_boundaries() {
         // act
         RegionBSPTree3D tree = RegionBSPTree3D.from(Arrays.asList(
-                    Facet.fromVertexLoop(Arrays.asList(
+                    ConvexSubPlane.fromVertexLoop(Arrays.asList(
                             Vector3D.ZERO, Vector3D.Unit.PLUS_X, Vector3D.Unit.PLUS_Y), TEST_PRECISION),
-                    Facet.fromVertexLoop(Arrays.asList(
+                    ConvexSubPlane.fromVertexLoop(Arrays.asList(
                             Vector3D.ZERO, Vector3D.Unit.MINUS_Z, Vector3D.Unit.PLUS_X), TEST_PRECISION)
                 ));
 
@@ -284,9 +284,9 @@ public class RegionBSPTree3DTest {
     public void testFrom_boundaries_fullIsTrue() {
         // act
         RegionBSPTree3D tree = RegionBSPTree3D.from(Arrays.asList(
-                    Facet.fromVertexLoop(Arrays.asList(
+                    ConvexSubPlane.fromVertexLoop(Arrays.asList(
                             Vector3D.ZERO, Vector3D.Unit.PLUS_X, Vector3D.Unit.PLUS_Y), TEST_PRECISION),
-                    Facet.fromVertexLoop(Arrays.asList(
+                    ConvexSubPlane.fromVertexLoop(Arrays.asList(
                             Vector3D.ZERO, Vector3D.Unit.MINUS_Z, Vector3D.Unit.PLUS_X), TEST_PRECISION)
                 ), true);
 
@@ -464,13 +464,13 @@ public class RegionBSPTree3DTest {
         // arrange
         RegionBSPTree3D a = RegionBSPTree3D.empty();
         Parallelepiped.axisAligned(Vector3D.ZERO, Vector3D.of(0.5, 1, 1), TEST_PRECISION).stream()
-            .map(Facet::reverse)
+            .map(ConvexSubPlane::reverse)
             .forEach(a::insert);
         a.complement();
 
         RegionBSPTree3D b = RegionBSPTree3D.empty();
         Parallelepiped.axisAligned(Vector3D.of(0.5, 0, 0), Vector3D.of(1, 1, 1), TEST_PRECISION).stream()
-            .map(Facet::reverse)
+            .map(ConvexSubPlane::reverse)
             .forEach(b::insert);
         b.complement();
 
@@ -923,11 +923,11 @@ public class RegionBSPTree3DTest {
         Vector3D vertex3 = Vector3D.of(2, 3, 3);
         Vector3D vertex4 = Vector3D.of(1, 3, 4);
 
-        List<Facet> boundaries = Arrays.asList(
-                Facet.fromVertexLoop(Arrays.asList(vertex3, vertex2, vertex1), TEST_PRECISION),
-                Facet.fromVertexLoop(Arrays.asList(vertex2, vertex3, vertex4), TEST_PRECISION),
-                Facet.fromVertexLoop(Arrays.asList(vertex4, vertex3, vertex1), TEST_PRECISION),
-                Facet.fromVertexLoop(Arrays.asList(vertex1, vertex2, vertex4), TEST_PRECISION)
+        List<ConvexSubPlane> boundaries = Arrays.asList(
+                ConvexSubPlane.fromVertexLoop(Arrays.asList(vertex3, vertex2, vertex1), TEST_PRECISION),
+                ConvexSubPlane.fromVertexLoop(Arrays.asList(vertex2, vertex3, vertex4), TEST_PRECISION),
+                ConvexSubPlane.fromVertexLoop(Arrays.asList(vertex4, vertex3, vertex1), TEST_PRECISION),
+                ConvexSubPlane.fromVertexLoop(Arrays.asList(vertex1, vertex2, vertex4), TEST_PRECISION)
             );
 
         // act
@@ -1525,7 +1525,7 @@ public class RegionBSPTree3DTest {
             {3, 0, 4, 7}
         };
 
-        List<Facet> faces = indexedFacetsToBoundaries(vertices, facets);
+        List<ConvexSubPlane> faces = indexedFacetsToBoundaries(vertices, facets);
 
         // act
         RegionBSPTree3D tree = RegionBSPTree3D.full();
@@ -1542,8 +1542,8 @@ public class RegionBSPTree3DTest {
                 Vector3D.of(-1, 1, 1), Vector3D.of(4, 1, 1));
     }
 
-    private static List<Facet> indexedFacetsToBoundaries(Vector3D[] vertices, int[][] facets) {
-        List<Facet> boundaries = new ArrayList<>();
+    private static List<ConvexSubPlane> indexedFacetsToBoundaries(Vector3D[] vertices, int[][] facets) {
+        List<ConvexSubPlane> boundaries = new ArrayList<>();
 
         List<Vector3D> vertexList = new ArrayList<>();
 
@@ -1554,7 +1554,7 @@ public class RegionBSPTree3DTest {
                 vertexList.add(vertices[indices[j]]);
             }
 
-            boundaries.add(Facet.fromVertexLoop(vertexList, TEST_PRECISION));
+            boundaries.add(ConvexSubPlane.fromVertexLoop(vertexList, TEST_PRECISION));
 
             vertexList.clear();
         }

--- a/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/threed/SubPlaneTest.java
+++ b/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/threed/SubPlaneTest.java
@@ -93,7 +93,7 @@ public class SubPlaneTest {
         SubPlane sp = new SubPlane(XY_PLANE, true);
 
         // act
-        List<Facet> convex = sp.toConvex();
+        List<ConvexSubPlane> convex = sp.toConvex();
 
         // assert
         Assert.assertEquals(1, convex.size());
@@ -106,7 +106,7 @@ public class SubPlaneTest {
         SubPlane sp = new SubPlane(XY_PLANE, false);
 
         // act
-        List<Facet> convex = sp.toConvex();
+        List<ConvexSubPlane> convex = sp.toConvex();
 
         // assert
         Assert.assertEquals(0, convex.size());
@@ -125,11 +125,11 @@ public class SubPlaneTest {
                 ), TEST_PRECISION);
 
         SubPlane sp = new SubPlane(XY_PLANE, false);
-        sp.add(Facet.fromConvexArea(XY_PLANE, a));
-        sp.add(Facet.fromConvexArea(XY_PLANE, b));
+        sp.add(ConvexSubPlane.fromConvexArea(XY_PLANE, a));
+        sp.add(ConvexSubPlane.fromConvexArea(XY_PLANE, b));
 
         // act
-        List<Facet> convex = sp.toConvex();
+        List<ConvexSubPlane> convex = sp.toConvex();
 
         // assert
         Assert.assertEquals(2, convex.size());
@@ -428,7 +428,7 @@ public class SubPlaneTest {
                 Vector3D.of(1e-16, 0, 1), Vector3D.of(1, 1e-16, 0), Vector3D.Unit.PLUS_Y, TEST_PRECISION);
 
         // act
-        builder.add(Facet.fromConvexArea(closePlane, a));
+        builder.add(ConvexSubPlane.fromConvexArea(closePlane, a));
         builder.add(new SubPlane(closePlane, b.toTree()));
 
         SubPlane result = builder.build();
@@ -455,7 +455,7 @@ public class SubPlaneTest {
 
         // act/assert
         GeometryTestUtils.assertThrows(() -> {
-            sp.add(Facet.fromConvexArea(
+            sp.add(ConvexSubPlane.fromConvexArea(
                     Plane.fromPointAndPlaneVectors(Vector3D.ZERO, Vector3D.Unit.PLUS_Y, Vector3D.Unit.MINUS_X, TEST_PRECISION),
                     ConvexArea.full()));
         }, IllegalArgumentException.class);

--- a/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/threed/shapes/ParallelepipedTest.java
+++ b/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/threed/shapes/ParallelepipedTest.java
@@ -23,7 +23,7 @@ import org.apache.commons.geometry.core.precision.DoublePrecisionContext;
 import org.apache.commons.geometry.core.precision.EpsilonDoublePrecisionContext;
 import org.apache.commons.geometry.euclidean.EuclideanTestUtils;
 import org.apache.commons.geometry.euclidean.threed.BoundarySource3D;
-import org.apache.commons.geometry.euclidean.threed.Facet;
+import org.apache.commons.geometry.euclidean.threed.ConvexSubPlane;
 import org.apache.commons.geometry.euclidean.threed.RegionBSPTree3D;
 import org.apache.commons.geometry.euclidean.threed.Vector3D;
 import org.junit.Assert;
@@ -39,7 +39,7 @@ public class ParallelepipedTest {
     @Test
     public void testAxisAligned_minFirst() {
         // act
-        List<Facet> boundaries =
+        List<ConvexSubPlane> boundaries =
                 Parallelepiped.axisAligned(Vector3D.of(1, 2, 3), Vector3D.of(4, 5, 6), TEST_PRECISION);
 
         // assert
@@ -68,7 +68,7 @@ public class ParallelepipedTest {
     @Test
     public void testAxisAligned_maxFirst() {
         // act
-        List<Facet> boundaries =
+        List<ConvexSubPlane> boundaries =
                 Parallelepiped.axisAligned(Vector3D.of(4, 5, 6), Vector3D.of(1, 2, 3), TEST_PRECISION);
 
         // assert
@@ -124,9 +124,9 @@ public class ParallelepipedTest {
         }, IllegalArgumentException.class);
     }
 
-    private static void checkVertices(Facet facet, Vector3D... pts) {
-        List<Vector3D> actual = facet.getPlane().toSpace(
-                facet.getSubspaceRegion().getBoundaryPaths().get(0).getVertices());
+    private static void checkVertices(ConvexSubPlane subplane, Vector3D... pts) {
+        List<Vector3D> actual = subplane.getPlane().toSpace(
+                subplane.getSubspaceRegion().getBoundaryPaths().get(0).getVertices());
 
         Assert.assertEquals(pts.length, actual.size());
 

--- a/src/site/xdoc/userguide/index.xml
+++ b/src/site/xdoc/userguide/index.xml
@@ -704,7 +704,7 @@ Vector2D normal = pt.getNormal(); // (1.0, 0.0)
           </li>
           <li>
             ConvexSubHyperplane -
-            <a class="code" href="../commons-geometry-euclidean/apidocs/org/apache/commons/geometry/euclidean/threed/Facet.html">Facet</a>
+            <a class="code" href="../commons-geometry-euclidean/apidocs/org/apache/commons/geometry/euclidean/threed/ConvexSubPlane.html">ConvexSubPlane</a>
           </li>
           <li>
             Region
@@ -813,10 +813,10 @@ Vector3D[][] faceIndices = {
     {b1, b2, b3, b4}
 };
 
-// convert the vertices to facets and insert into a bsp tree
+// convert the vertices to convex subplanes and insert into a bsp tree
 RegionBSPTree3D tree = RegionBSPTree3D.empty();
 Arrays.stream(faceIndices)
-    .map(vertices -> Facet.fromVertexLoop(Arrays.asList(vertices), precision))
+    .map(vertices -> ConvexSubPlane.fromVertexLoop(Arrays.asList(vertices), precision))
     .forEach(tree::insert);
 
 // split the region through its barycenter along a diagonal of the base
@@ -824,11 +824,11 @@ Plane cutter = Plane.fromPointAndNormal(tree.getBarycenter(), Vector3D.Unit.from
 Split&lt;RegionBSPTree3D&gt; split = tree.split(cutter);
 
 // compute some properties for the minus side of the split and convert back to subhyperplanes
-// (ie, facets)
+// (ie, boundary facets)
 RegionBSPTree3D minus = split.getMinus();
 
 double minusSize = minus.getSize(); // 1/6
-List&lt;Facet&gt; minusFacets = minus.getBoundaries(); // size = 4
+List&lt;ConvexSubPlane&gt; minusBoundaries = minus.getBoundaries(); // size = 4
         </source>
 
         <h5>Linecast</h5>


### PR DESCRIPTION
Naming Facet class back to ConvexSubPlane.