### PR TITLE
GEOMETRY-90: Slerp Wrapper Class

### DIFF
--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/rotation/QuaternionRotation.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/rotation/QuaternionRotation.java
@@ -25,7 +25,6 @@ import org.apache.commons.geometry.euclidean.threed.Vector3D;
 import org.apache.commons.numbers.angle.PlaneAngleRadians;
 import org.apache.commons.numbers.arrays.LinearCombination;
 import org.apache.commons.numbers.quaternion.Quaternion;
-import org.apache.commons.numbers.quaternion.Slerp;
 
 /**
  * Class using a unit-length quaternion to represent
@@ -256,13 +255,16 @@ public final class QuaternionRotation implements Rotation3D {
     }
 
     /**
-     * Creates a {@link Slerp} transform.
+     * Create a {@link SlerpFunction} instance that can be used to perform spherical
+     * linear interpolation between this instance and the argument.
      *
-     * @param end End rotation of the interpolation.
-     * @return the transform.
+     * @param end end value of the interpolation
+     * @return function that can be used to interpolate between this instance and
+     *      the argument
+     * @see <a href="https://en.wikipedia.org/wiki/Slerp">Slerp</a>
      */
-    public Slerp slerp(QuaternionRotation end) {
-        return new Slerp(quat, end.quat);
+    public SlerpFunction slerp(final QuaternionRotation end) {
+        return new SlerpFunction(this, end);
     }
 
     /** Get a sequence of axis-angle rotations that produce an overall rotation equivalent to this instance.

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/rotation/SlerpFunction.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/rotation/SlerpFunction.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.geometry.euclidean.threed.rotation;
+
+import java.util.function.DoubleFunction;
+
+import org.apache.commons.numbers.quaternion.Slerp;
+
+/** Class used to perform spherical linear interpolation (ie, "Slerp") between quaternion rotations.
+ * This class serves as a geometry-specific wrapper around the generic {@link Slerp} class.
+ * @see org.apache.commons.numbers.quaternion.Slerp
+ * @see <a href="https://en.wikipedia.org/wiki/Slerp">Slerp</a>
+ */
+public final class SlerpFunction implements DoubleFunction<QuaternionRotation> {
+
+    /** The start rotation. */
+    private final QuaternionRotation start;
+
+    /** The end rotation. */
+    private final QuaternionRotation end;
+
+    /** Slerp instance that will perform the interpolation. */
+    private final Slerp slerp;
+
+    /** Create a new instance that interpolates between the given start and end rotations.
+     * @param start start of the interpolation
+     * @param end end of the interpolation
+     */
+    public SlerpFunction(final QuaternionRotation start, final QuaternionRotation end) {
+        this.start = start;
+        this.end = end;
+        this.slerp = new Slerp(start.getQuaternion(), end.getQuaternion());
+    }
+
+    /** Get the start value for the interpolation.
+     * @return the start value for the interpolation
+     */
+    public QuaternionRotation getStart() {
+        return start;
+    }
+
+    /** Get the end value for the interpolation.
+     * @return the end value for the interpolation
+     */
+    public QuaternionRotation getEnd() {
+        return end;
+    }
+
+    /** Perform the interpolation. The rotation returned by this method is controlled by the interpolation
+     * parameter, {@code t}. If {@code t = 0}, a rotation equal to the start instance is returned. If {@code t = 1},
+     * a rotation equal to the end instance is returned.  All other values are interpolated (or extrapolated if
+     * {@code t} is outside of the {@code [0, 1]} range).
+     * @param t interpolation control parameter
+     * @return an interpolated rotation
+     */
+    @Override
+    public QuaternionRotation apply(final double t) {
+        return QuaternionRotation.of(slerp.apply(t));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder();
+        sb.append(this.getClass().getSimpleName())
+            .append("[start= ")
+            .append(start)
+            .append(", end= ")
+            .append(end)
+            .append(']');
+
+        return sb.toString();
+    }
+}

--- a/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/threed/rotation/SlerpFunctionTest.java
+++ b/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/threed/rotation/SlerpFunctionTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.geometry.euclidean.threed.rotation;
+
+import org.apache.commons.geometry.core.GeometryTestUtils;
+import org.apache.commons.geometry.euclidean.EuclideanTestUtils;
+import org.apache.commons.geometry.euclidean.threed.Vector3D;
+import org.apache.commons.numbers.angle.PlaneAngleRadians;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SlerpFunctionTest {
+
+    private static final double TEST_EPS = 1e-12;
+
+    @Test
+    public void testProperties() {
+        // arrange
+        QuaternionRotation start = QuaternionRotation.fromAxisAngle(Vector3D.Unit.PLUS_X, 0.0);
+        QuaternionRotation end = QuaternionRotation.fromAxisAngle(Vector3D.Unit.PLUS_X, PlaneAngleRadians.PI_OVER_TWO);
+
+        // act
+        SlerpFunction fn = new SlerpFunction(start, end);
+
+        // assert
+        Assert.assertSame(start, fn.getStart());
+        Assert.assertSame(end, fn.getEnd());
+    }
+
+    @Test
+    public void testApply() {
+        // arrange
+        QuaternionRotation start = QuaternionRotation.fromAxisAngle(Vector3D.Unit.PLUS_Z, 0.0);
+        QuaternionRotation end = QuaternionRotation.fromAxisAngle(Vector3D.Unit.PLUS_Z, PlaneAngleRadians.PI_OVER_TWO);
+
+        // act
+        SlerpFunction fn = new SlerpFunction(start, end);
+
+        // assert
+        Vector3D pt = Vector3D.Unit.PLUS_X;
+
+        EuclideanTestUtils.assertCoordinatesEqual(Vector3D.of(1, -1, 0).normalize(), fn.apply(-0.5).apply(pt), TEST_EPS);
+        EuclideanTestUtils.assertCoordinatesEqual(Vector3D.Unit.PLUS_X, fn.apply(0).apply(pt), TEST_EPS);
+        EuclideanTestUtils.assertCoordinatesEqual(Vector3D.of(1, 1, 0).normalize(), fn.apply(0.5).apply(pt), TEST_EPS);
+        EuclideanTestUtils.assertCoordinatesEqual(Vector3D.Unit.PLUS_Y, fn.apply(1).apply(pt), TEST_EPS);
+        EuclideanTestUtils.assertCoordinatesEqual(Vector3D.of(-1, 1, 0).normalize(), fn.apply(1.5).apply(pt), TEST_EPS);
+    }
+
+    @Test
+    public void testToString() {
+        // arrange
+        QuaternionRotation start = QuaternionRotation.fromAxisAngle(Vector3D.Unit.PLUS_X, 0.0);
+        QuaternionRotation end = QuaternionRotation.fromAxisAngle(Vector3D.Unit.PLUS_X, PlaneAngleRadians.PI_OVER_TWO);
+
+        SlerpFunction fn = new SlerpFunction(start, end);
+
+        // act
+        String str = fn.toString();
+
+        // assert
+        GeometryTestUtils.assertContains("SlerpFunction[", str);
+        GeometryTestUtils.assertContains("start= [1", str);
+        GeometryTestUtils.assertContains("end= [0.7", str);
+    }
+}

--- a/commons-geometry-spherical/src/main/java/org/apache/commons/geometry/spherical/twod/Point2S.java
+++ b/commons-geometry-spherical/src/main/java/org/apache/commons/geometry/spherical/twod/Point2S.java
@@ -175,7 +175,7 @@ public final class Point2S implements Point<Point2S> {
         final QuaternionRotation start = QuaternionRotation.identity();
         final QuaternionRotation end = QuaternionRotation.createVectorRotation(getVector(), other.getVector());
 
-        final QuaternionRotation quat = QuaternionRotation.of(start.slerp(end).apply(t));
+        final QuaternionRotation quat = start.slerp(end).apply(t);
 
         return Point2S.from(quat.apply(getVector()));
     }


### PR DESCRIPTION
Adding small wrapper class around the commons-numbers Slerp class to avoid object conversions when working with QuaternionRotation instances.