### PR TITLE
Windows Build Fixes

### DIFF
--- a/commons-geometry-spherical/src/test/java/org/apache/commons/geometry/spherical/twod/ConvexArea2STest.java
+++ b/commons-geometry-spherical/src/test/java/org/apache/commons/geometry/spherical/twod/ConvexArea2STest.java
@@ -228,7 +228,7 @@ public class ConvexArea2STest {
     @Test
     public void testFromBounds_triangle_small() {
         // arrange
-        final double azMin = 1.125 * PlaneAngleRadians.PI;
+        final double azMin = 1.12 * PlaneAngleRadians.PI;
         final double azMax = 1.375 * PlaneAngleRadians.PI;
         final double azMid = 0.5 * (azMin + azMax);
         final double polarTop = 0.1;

--- a/src/main/resources/checkstyle/checkstyle-suppressions.xml
+++ b/src/main/resources/checkstyle/checkstyle-suppressions.xml
@@ -28,7 +28,7 @@
   <!-- allow Vector3D.linearCombination() methods -->
   <suppress checks="ParameterNumber" files=".*[/\\]threed[/\\]Vector3D" />
   <!-- allow internal, non-array QuaterionRotation.orthogonalRotationMatrixToQuaternion() method -->
-  <suppress checks="ParameterNumber" files=".*[/\\]threed/rotation[/\\]QuaternionRotation" />
+  <suppress checks="ParameterNumber" files=".*[/\\]threed[/\\]rotation[/\\]QuaternionRotation" />
   <!-- allow Vector2D.linearCombination() methods -->
   <suppress checks="ParameterNumber" files=".*[/\\]twod[/\\]Vector2D" />
   <!-- Prevent subclass error on generic package-private methods (checkstyle parsing issue?) -->


### PR DESCRIPTION
- fixing checkstyle suppression on windows
- adjusting unit test value for more consistent result sorting