### PR TITLE
Fix OSGi Header + add method for direct transformation

### DIFF
--- a/commons-geometry-core/pom.xml
+++ b/commons-geometry-core/pom.xml
@@ -34,7 +34,7 @@
   <properties>
     <!-- OSGi -->
     <commons.osgi.symbolicName>org.apache.commons.geometry.core</commons.osgi.symbolicName>
-    <commons.osgi.export>org.apache.commons.geometry.core</commons.osgi.export>
+    <commons.osgi.export>org.apache.commons.geometry.core.*</commons.osgi.export>
     <!-- Java 9+ -->
     <commons.automatic.module.name>org.apache.commons.geometry.core</commons.automatic.module.name>
     <!-- Workaround to avoid duplicating config files. -->

--- a/commons-geometry-enclosing/pom.xml
+++ b/commons-geometry-enclosing/pom.xml
@@ -34,9 +34,9 @@
   <properties>
     <!-- OSGi -->
     <commons.osgi.symbolicName>org.apache.commons.geometry.enclosing</commons.osgi.symbolicName>
-    <commons.osgi.export>org.apache.commons.geometry.enclosing</commons.osgi.export>
+    <commons.osgi.export>org.apache.commons.geometry.enclosing.*</commons.osgi.export>
     <!-- Java 9+ -->
-    <commons.automatic.module.name>org.apache.commons.geometry.enclosing.*</commons.automatic.module.name>
+    <commons.automatic.module.name>org.apache.commons.geometry.enclosing</commons.automatic.module.name>
     <!-- Workaround to avoid duplicating config files. -->
     <geometry.parent.dir>${basedir}/..</geometry.parent.dir>
   </properties>

--- a/commons-geometry-enclosing/pom.xml
+++ b/commons-geometry-enclosing/pom.xml
@@ -36,7 +36,7 @@
     <commons.osgi.symbolicName>org.apache.commons.geometry.enclosing</commons.osgi.symbolicName>
     <commons.osgi.export>org.apache.commons.geometry.enclosing</commons.osgi.export>
     <!-- Java 9+ -->
-    <commons.automatic.module.name>org.apache.commons.geometry.enclosing</commons.automatic.module.name>
+    <commons.automatic.module.name>org.apache.commons.geometry.enclosing.*</commons.automatic.module.name>
     <!-- Workaround to avoid duplicating config files. -->
     <geometry.parent.dir>${basedir}/..</geometry.parent.dir>
   </properties>

--- a/commons-geometry-euclidean/pom.xml
+++ b/commons-geometry-euclidean/pom.xml
@@ -34,7 +34,7 @@
   <properties>
     <!-- OSGi -->
     <commons.osgi.symbolicName>org.apache.commons.geometry.euclidean</commons.osgi.symbolicName>
-    <commons.osgi.export>org.apache.commons.geometry.euclidean,org.apache.commons.geometry.euclidean.oned,org.apache.commons.geometry.euclidean.twod,org.apache.commons.geometry.euclidean.threed</commons.osgi.export>
+    <commons.osgi.export>org.apache.commons.geometry.euclidean.*</commons.osgi.export>
     <!-- Java 9+ -->
     <commons.automatic.module.name>org.apache.commons.geometry.euclidean</commons.automatic.module.name>
     <!-- Workaround to avoid duplicating config files. -->

--- a/commons-geometry-euclidean/pom.xml
+++ b/commons-geometry-euclidean/pom.xml
@@ -34,7 +34,7 @@
   <properties>
     <!-- OSGi -->
     <commons.osgi.symbolicName>org.apache.commons.geometry.euclidean</commons.osgi.symbolicName>
-    <commons.osgi.export>org.apache.commons.geometry.euclidean</commons.osgi.export>
+    <commons.osgi.export>org.apache.commons.geometry.euclidean,org.apache.commons.geometry.euclidean.oned,org.apache.commons.geometry.euclidean.twod,org.apache.commons.geometry.euclidean.threed</commons.osgi.export>
     <!-- Java 9+ -->
     <commons.automatic.module.name>org.apache.commons.geometry.euclidean</commons.automatic.module.name>
     <!-- Workaround to avoid duplicating config files. -->

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/AffineTransformMatrix2D.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/AffineTransformMatrix2D.java
@@ -134,20 +134,29 @@ public final class AffineTransformMatrix2D extends AbstractAffineTransformMatrix
         return Vector2D.of(resultX, resultY);
     }
 
-    /**
-     * Applys the transform directly to the given array.
-     *
-     * @param x
-     * @param y
-     */
-    public void applyDirect(final double[] x, double[] y) {
-
-        for (int i = 0; i < x.length; i++) {
-            final double resultX = LinearCombination.value(m00, x[i], m01, y[i]) + m02;
-            final double resultY = LinearCombination.value(m10, x[i], m11, y[i]) + m12;
-            x[i] = resultX;
-            y[i] = resultY;
+    public double transformX(final double x) {
+        if (m01 != 0.0) {
+            throw new IllegalStateException(
+                    "maxtrix contains y-shear value, you need to call the two argument variant of this function");
         }
+        return m00 * x + m02;
+    }
+
+    public double transformX(final double x, double y) {
+        return LinearCombination.value(m00, x, m01, y) + m02;
+    }
+
+    public double transformY(double y) {
+        if (m10 != 0.0) {
+            throw new IllegalStateException(
+                    "maxtrix contains x-shear value, you need to call the two argument variant of this function");
+        }
+        return m11 * y + m12;
+    }
+
+    public double transformY(final double x, double y) {
+
+        return LinearCombination.value(m10, x, m11, y) + m12;
     }
 
     /** {@inheritDoc}
@@ -238,6 +247,20 @@ public final class AffineTransformMatrix2D extends AbstractAffineTransformMatrix
                     m00, m01, m02 + x,
                     m10, m11, m12 + y
                 );
+    }
+
+    /**
+     * Apply a shear to the current instance, returning the result as a new transform.
+     * @param shx shear in x-direction
+     * @param shy shear in y direction
+     * @return a new transform containing the result of applying a shear to
+     *      the current instance
+     */
+    public AffineTransformMatrix2D shear(double shx, double shy) {
+        return multiply(AffineTransformMatrix2D.of(
+                1.0, shx, 0.0,
+                shy, 1.0, 0.0
+        ), this);
     }
 
     /** Apply a scale operation to the current instance, returning the result as a new transform.

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/AffineTransformMatrix2D.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/AffineTransformMatrix2D.java
@@ -134,6 +134,22 @@ public final class AffineTransformMatrix2D extends AbstractAffineTransformMatrix
         return Vector2D.of(resultX, resultY);
     }
 
+    /**
+     * Applys the transform directly to the given array.
+     *
+     * @param x
+     * @param y
+     */
+    public void applyDirect(final double[] x, double[] y) {
+
+        for (int i = 0; i < x.length; i++) {
+            final double resultX = LinearCombination.value(m00, x[i], m01, y[i]) + m02;
+            final double resultY = LinearCombination.value(m10, x[i], m11, y[i]) + m12;
+            x[i] = resultX;
+            y[i] = resultY;
+        }
+    }
+
     /** {@inheritDoc}
     *
     *  <p>The transformed vector is computed by creating a 3-element column vector from the

--- a/commons-geometry-hull/pom.xml
+++ b/commons-geometry-hull/pom.xml
@@ -34,7 +34,7 @@
   <properties>
     <!-- OSGi -->
     <commons.osgi.symbolicName>org.apache.commons.geometry.hull</commons.osgi.symbolicName>
-    <commons.osgi.export>org.apache.commons.geometry.hull</commons.osgi.export>
+    <commons.osgi.export>org.apache.commons.geometry.hull.*</commons.osgi.export>
     <!-- Java 9+ -->
     <commons.automatic.module.name>org.apache.commons.geometry.hull</commons.automatic.module.name>
     <!-- Workaround to avoid duplicating config files. -->

--- a/commons-geometry-spherical/pom.xml
+++ b/commons-geometry-spherical/pom.xml
@@ -34,7 +34,7 @@
   <properties>
     <!-- OSGi -->
     <commons.osgi.symbolicName>org.apache.commons.geometry.spherical</commons.osgi.symbolicName>
-    <commons.osgi.export>org.apache.commons.geometry.spherical</commons.osgi.export>
+    <commons.osgi.export>org.apache.commons.geometry.spherical.*</commons.osgi.export>
     <!-- Java 9+ -->
     <commons.automatic.module.name>org.apache.commons.geometry.spherical</commons.automatic.module.name>
     <!-- Workaround to avoid duplicating config files. -->


### PR DESCRIPTION
As mentioned in the mailing list the OSGi headers currently do not work because of missing exports.
It would also be good to have an "applyDirect" method to prevent massive object creation when transforming x/y arrays.