### PR TITLE
GEOMETRY-118: Component-specific transform methods

### DIFF
--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/oned/AffineTransformMatrix1D.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/oned/AffineTransformMatrix1D.java
@@ -18,7 +18,6 @@ package org.apache.commons.geometry.euclidean.oned;
 
 import java.util.function.UnaryOperator;
 
-import org.apache.commons.geometry.core.internal.DoubleFunction1N;
 import org.apache.commons.geometry.euclidean.AbstractAffineTransformMatrix;
 import org.apache.commons.geometry.euclidean.internal.Matrices;
 import org.apache.commons.geometry.euclidean.internal.Vectors;
@@ -83,11 +82,17 @@ public final class AffineTransformMatrix1D extends AbstractAffineTransformMatrix
     /** {@inheritDoc} */
     @Override
     public Vector1D apply(final Vector1D vec) {
-        final double x = vec.getX();
+        return Vector1D.of(applyX(vec.getX()));
+    }
 
-        final double resultX = (m00 * x) + m01;
-
-        return Vector1D.of(resultX);
+    /** Apply this transform to the given point coordinate and return the transformed
+     * x value. The return value is equal to <code>(x * m<sub>00</sub>) + m<sub>01</sub></code>.
+     * @param x x coordinate value
+     * @return transformed x coordinate value
+     * @see #apply(Vector1D)
+     */
+    public double applyX(final double x) {
+        return applyVectorX(x) + m01;
     }
 
     /** {@inheritDoc}
@@ -95,7 +100,17 @@ public final class AffineTransformMatrix1D extends AbstractAffineTransformMatrix
      */
     @Override
     public Vector1D applyVector(final Vector1D vec) {
-        return applyVector(vec, Vector1D::of);
+        return Vector1D.of(applyVectorX(vec.getX()));
+    }
+
+    /** Apply this transform to the given vector coordinate, ignoring translations, and
+     * return the transformed x value. The return value is equal to <code>x * m<sub>00</sub></code>.
+     * @param x x coordinate value
+     * @return transformed x coordinate value
+     * @see #applyVector(Vector1D)
+     */
+    public double applyVectorX(final double x) {
+        return x * m00;
     }
 
     /** {@inheritDoc}
@@ -103,7 +118,7 @@ public final class AffineTransformMatrix1D extends AbstractAffineTransformMatrix
      */
     @Override
     public Vector1D.Unit applyDirection(final Vector1D vec) {
-        return applyVector(vec, Vector1D.Unit::from);
+        return Vector1D.Unit.from(applyVectorX(vec.getX()));
     }
 
     /** {@inheritDoc} */
@@ -290,19 +305,6 @@ public final class AffineTransformMatrix1D extends AbstractAffineTransformMatrix
             .append(MATRIX_END);
 
         return sb.toString();
-    }
-
-    /** Multiplies the given vector by the scaling component of this transform.
-     * The computed coordinate is passed to the given factory function.
-     * @param <T> factory output type
-     * @param vec the vector to transform
-     * @param factory the factory instance that will be passed the transformed coordinate
-     * @return the factory return value
-     */
-    private <T> T applyVector(final Vector1D vec, final DoubleFunction1N<T> factory) {
-        final double resultX = m00 * vec.getX();
-
-        return factory.apply(resultX);
     }
 
     /** Get a new transform with the given matrix elements. The array must contain 2 elements.

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/AffineTransformMatrix3D.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/AffineTransformMatrix3D.java
@@ -160,11 +160,49 @@ public final class AffineTransformMatrix3D extends AbstractAffineTransformMatrix
         final double y = pt.getY();
         final double z = pt.getZ();
 
-        final double resultX = LinearCombination.value(m00, x, m01, y, m02, z) + m03;
-        final double resultY = LinearCombination.value(m10, x, m11, y, m12, z) + m13;
-        final double resultZ = LinearCombination.value(m20, x, m21, y, m22, z) + m23;
+        return Vector3D.of(
+                applyX(x, y, z),
+                applyY(x, y, z),
+                applyZ(x, y, z));
+    }
 
-        return Vector3D.of(resultX, resultY, resultZ);
+    /** Apply this transform to the given point coordinates and return the transformed
+     * x value. The return value is equal to
+     * <code>(x * m<sub>00</sub>) + (y * m<sub>01</sub>) + (z * m<sub>02</sub>) + m<sub>03</sub></code>.
+     * @param x x coordinate value
+     * @param y y coordinate value
+     * @param z z coordinate value
+     * @return transformed x coordinate value
+     * @see #apply(Vector3D)
+     */
+    public double applyX(final double x, final double y, final double z) {
+        return applyVectorX(x, y, z) + m03;
+    }
+
+    /** Apply this transform to the given point coordinates and return the transformed
+     * y value. The return value is equal to
+     * <code>(x * m<sub>10</sub>) + (y * m<sub>11</sub>) + (z * m<sub>12</sub>) + m<sub>13</sub></code>.
+     * @param x x coordinate value
+     * @param y y coordinate value
+     * @param z z coordinate value
+     * @return transformed y coordinate value
+     * @see #apply(Vector3D)
+     */
+    public double applyY(final double x, final double y, final double z) {
+        return applyVectorY(x, y, z) + m13;
+    }
+
+    /** Apply this transform to the given point coordinates and return the transformed
+     * z value. The return value is equal to
+     * <code>(x * m<sub>20</sub>) + (y * m<sub>21</sub>) + (z * m<sub>22</sub>) + m<sub>23</sub></code>.
+     * @param x x coordinate value
+     * @param y y coordinate value
+     * @param z z coordinate value
+     * @return transformed z coordinate value
+     * @see #apply(Vector3D)
+     */
+    public double applyZ(final double x, final double y, final double z) {
+        return applyVectorZ(x, y, z) + m23;
     }
 
     /** {@inheritDoc}
@@ -185,6 +223,45 @@ public final class AffineTransformMatrix3D extends AbstractAffineTransformMatrix
     @Override
     public Vector3D applyVector(final Vector3D vec) {
         return applyVector(vec, Vector3D::of);
+    }
+
+    /** Apply this transform to the given vector coordinates, ignoring translations, and
+     * return the transformed x value. The return value is equal to
+     * <code>(x * m<sub>00</sub>) + (y * m<sub>01</sub>) + (z * m<sub>02</sub>)</code>.
+     * @param x x coordinate value
+     * @param y y coordinate value
+     * @param z z coordinate value
+     * @return transformed x coordinate value
+     * @see #applyVector(Vector3D)
+     */
+    public double applyVectorX(final double x, final double y, final double z) {
+        return LinearCombination.value(m00, x, m01, y, m02, z);
+    }
+
+    /** Apply this transform to the given vector coordinates, ignoring translations, and
+     * return the transformed y value. The return value is equal to
+     * <code>(x * m<sub>10</sub>) + (y * m<sub>11</sub>) + (z * m<sub>12</sub>)</code>.
+     * @param x x coordinate value
+     * @param y y coordinate value
+     * @param z z coordinate value
+     * @return transformed y coordinate value
+     * @see #applyVector(Vector3D)
+     */
+    public double applyVectorY(final double x, final double y, final double z) {
+        return LinearCombination.value(m10, x, m11, y, m12, z);
+    }
+
+    /** Apply this transform to the given vector coordinates, ignoring translations, and
+     * return the transformed z value. The return value is equal to
+     * <code>(x * m<sub>20</sub>) + (y * m<sub>21</sub>) + (z * m<sub>22</sub>)</code>.
+     * @param x x coordinate value
+     * @param y y coordinate value
+     * @param z z coordinate value
+     * @return transformed z coordinate value
+     * @see #applyVector(Vector3D)
+     */
+    public double applyVectorZ(final double x, final double y, final double z) {
+        return LinearCombination.value(m20, x, m21, y, m22, z);
     }
 
     /** {@inheritDoc}
@@ -509,11 +586,10 @@ public final class AffineTransformMatrix3D extends AbstractAffineTransformMatrix
         final double y = vec.getY();
         final double z = vec.getZ();
 
-        final double resultX = LinearCombination.value(m00, x, m01, y, m02, z);
-        final double resultY = LinearCombination.value(m10, x, m11, y, m12, z);
-        final double resultZ = LinearCombination.value(m20, x, m21, y, m22, z);
-
-        return factory.apply(resultX, resultY, resultZ);
+        return factory.apply(
+                applyVectorX(x, y, z),
+                applyVectorY(x, y, z),
+                applyVectorZ(x, y, z));
     }
 
     /** Get a new transform with the given matrix elements. The array must contain 12 elements.

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/AffineTransformMatrix2D.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/AffineTransformMatrix2D.java
@@ -128,10 +128,33 @@ public final class AffineTransformMatrix2D extends AbstractAffineTransformMatrix
         final double x = pt.getX();
         final double y = pt.getY();
 
-        final double resultX = LinearCombination.value(m00, x, m01, y) + m02;
-        final double resultY = LinearCombination.value(m10, x, m11, y) + m12;
+        return Vector2D.of(
+                applyX(x, y),
+                applyY(x, y));
+    }
 
-        return Vector2D.of(resultX, resultY);
+    /** Apply this transform to the given point coordinates and return the transformed
+     * x value. The return value is equal to
+     * <code>(x * m<sub>00</sub>) + (y * m<sub>01</sub>) + m<sub>02</sub></code>.
+     * @param x x coordinate value
+     * @param y y coordinate value
+     * @return transformed x coordinate value
+     * @see #apply(Vector2D)
+     */
+    public double applyX(final double x, final double y) {
+        return applyVectorX(x, y) + m02;
+    }
+
+    /** Apply this transform to the given point coordinates and return the transformed
+     * y value. The return value is equal to
+     * <code>(x * m<sub>10</sub>) + (y * m<sub>11</sub>) + m<sub>12</sub></code>.
+     * @param x x coordinate value
+     * @param y y coordinate value
+     * @return transformed y coordinate value
+     * @see #apply(Vector2D)
+     */
+    public double applyY(final double x, final double y) {
+        return applyVectorY(x, y) + m12;
     }
 
     /** {@inheritDoc}
@@ -151,6 +174,30 @@ public final class AffineTransformMatrix2D extends AbstractAffineTransformMatrix
     @Override
     public Vector2D applyVector(final Vector2D vec) {
         return applyVector(vec, Vector2D::of);
+    }
+
+    /** Apply this transform to the given vector coordinates, ignoring translations, and
+     * return the transformed x value. The return value is equal to
+     * <code>(x * m<sub>00</sub>) + (y * m<sub>01</sub>)</code>.
+     * @param x x coordinate value
+     * @param y y coordinate value
+     * @return transformed x coordinate value
+     * @see #applyVector(Vector2D)
+     */
+    public double applyVectorX(final double x, final double y) {
+        return LinearCombination.value(m00, x, m01, y);
+    }
+
+    /** Apply this transform to the given vector coordinates, ignoring translations, and
+     * return the transformed y value. The return value is equal to
+     * <code>(x * m<sub>10</sub>) + (y * m<sub>11</sub>)</code>.
+     * @param x x coordinate value
+     * @param y y coordinate value
+     * @return transformed y coordinate value
+     * @see #applyVector(Vector2D)
+     */
+    public double applyVectorY(final double x, final double y) {
+        return LinearCombination.value(m10, x, m11, y);
     }
 
     /** {@inheritDoc}
@@ -454,10 +501,9 @@ public final class AffineTransformMatrix2D extends AbstractAffineTransformMatrix
         final double x = vec.getX();
         final double y = vec.getY();
 
-        final double resultX = LinearCombination.value(m00, x, m01, y);
-        final double resultY = LinearCombination.value(m10, x, m11, y);
-
-        return factory.apply(resultX, resultY);
+        return factory.apply(
+                applyVectorX(x, y),
+                applyVectorY(x, y));
     }
 
     /** Get a new transform with the given matrix elements. The array must contain 6 elements.

--- a/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/oned/AffineTransformMatrix1DTest.java
+++ b/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/oned/AffineTransformMatrix1DTest.java
@@ -282,6 +282,24 @@ public class AffineTransformMatrix1DTest {
     }
 
     @Test
+    public void testApplyX() {
+        // arrange
+        final Vector1D translation = Vector1D.of(-2.0);
+        final Vector1D scale = Vector1D.of(5.0);
+
+        final AffineTransformMatrix1D transform = AffineTransformMatrix1D.identity()
+                .translate(translation)
+                .scale(scale);
+
+        // act/assert
+        runWithCoordinates(x -> {
+            final double expected = (x + translation.getX()) * scale.getX();
+
+            Assertions.assertEquals(expected, transform.applyX(x), EPS);
+        });
+    }
+
+    @Test
     public void testApplyVector_identity() {
         // arrange
         final AffineTransformMatrix1D transform = AffineTransformMatrix1D.identity();
@@ -348,6 +366,28 @@ public class AffineTransformMatrix1DTest {
             final Vector1D expectedVec = transform.apply(p1).subtract(transform.apply(p2));
 
             EuclideanTestUtils.assertCoordinatesEqual(expectedVec, transform.applyVector(input), EPS);
+        });
+    }
+
+    @Test
+    public void testApplyVectorX() {
+        // arrange
+        final Vector1D p1 = Vector1D.of(PlaneAngleRadians.PI);
+
+        final Vector1D translation = Vector1D.of(-2.0);
+        final Vector1D scale = Vector1D.of(5.0);
+
+        final AffineTransformMatrix1D transform = AffineTransformMatrix1D.identity()
+                .translate(translation)
+                .scale(scale);
+
+        // act/assert
+        runWithCoordinates(x -> {
+            final Vector1D p2 = p1.add(Vector1D.of(x));
+
+            final double expected = transform.apply(p1).vectorTo(transform.apply(p2)).getX();
+
+            Assertions.assertEquals(expected, transform.applyVectorX(x), EPS);
         });
     }
 

--- a/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/threed/AffineTransformMatrix3DTest.java
+++ b/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/threed/AffineTransformMatrix3DTest.java
@@ -523,6 +523,28 @@ public class AffineTransformMatrix3DTest {
     }
 
     @Test
+    public void testApplyXYZ() {
+        // arrange
+        final double scaleFactor = 2;
+        final Vector3D center = Vector3D.of(3, -4, 5);
+        final QuaternionRotation rotation = QuaternionRotation.fromAxisAngle(Vector3D.of(0.5, 1, 1), 2 * Math.PI / 3);
+
+        final AffineTransformMatrix3D transform = AffineTransformMatrix3D.identity()
+                .scale(scaleFactor)
+                .rotate(center, rotation);
+
+        // act/assert
+        runWithCoordinates((x, y, z) -> {
+            final Vector3D vec = Vector3D.of(x, y, z);
+            final Vector3D expectedVec = rotation.apply(vec.multiply(scaleFactor).subtract(center)).add(center);
+
+            Assertions.assertEquals(expectedVec.getX(), transform.applyX(x, y, z), EPS);
+            Assertions.assertEquals(expectedVec.getY(), transform.applyY(x, y, z), EPS);
+            Assertions.assertEquals(expectedVec.getZ(), transform.applyZ(x, y, z), EPS);
+        });
+    }
+
+    @Test
     public void testApplyVector_identity() {
         // arrange
         final AffineTransformMatrix3D transform = AffineTransformMatrix3D.identity();
@@ -587,6 +609,28 @@ public class AffineTransformMatrix3DTest {
             final Vector3D expected = transform.apply(p1).subtract(transform.apply(p2));
 
             EuclideanTestUtils.assertCoordinatesEqual(expected, transform.applyVector(input), EPS);
+        });
+    }
+
+    @Test
+    public void testApplyVectorXYZ() {
+        // arrange
+        final Vector3D p1 = Vector3D.of(1, 2, 3);
+
+        final AffineTransformMatrix3D transform = AffineTransformMatrix3D.identity()
+                .scale(1.5)
+                .translate(4, 6, 5)
+                .rotate(QuaternionRotation.fromAxisAngle(Vector3D.of(0.5, 1, 1), PlaneAngleRadians.PI_OVER_TWO));
+
+        // act/assert
+        runWithCoordinates((x, y, z) -> {
+            final Vector3D p2 = p1.add(Vector3D.of(x, y, z));
+
+            final Vector3D expected = transform.apply(p1).vectorTo(transform.apply(p2));
+
+            Assertions.assertEquals(expected.getX(), transform.applyVectorX(x, y, z), EPS);
+            Assertions.assertEquals(expected.getY(), transform.applyVectorY(x, y, z), EPS);
+            Assertions.assertEquals(expected.getZ(), transform.applyVectorZ(x, y, z), EPS);
         });
     }
 

--- a/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/twod/AffineTransformMatrix2DTest.java
+++ b/commons-geometry-euclidean/src/test/java/org/apache/commons/geometry/euclidean/twod/AffineTransformMatrix2DTest.java
@@ -706,6 +706,36 @@ public class AffineTransformMatrix2DTest {
     }
 
     @Test
+    public void testApplyXY() {
+        // arrange
+        final Vector2D scale = Vector2D.of(5.0, 6.0);
+        final Vector2D translation = Vector2D.of(-2.0, -3.0);
+        final Vector2D shear = Vector2D.of(7, 8);
+
+        final AffineTransformMatrix2D transform = AffineTransformMatrix2D.identity()
+                .scale(scale)
+                .translate(translation)
+                .rotate(-PlaneAngleRadians.PI_OVER_TWO)
+                .shear(shear.getX(), shear.getY());
+
+        // act/assert
+        runWithCoordinates((x, y) -> {
+            final Vector2D scaledAndTranslated = Vector2D.of(
+                        (x * scale.getX()) + translation.getX(),
+                        (y * scale.getY()) + translation.getY()
+                    );
+            final Vector2D rotated = Vector2D.of(scaledAndTranslated.getY(), -scaledAndTranslated.getX());
+            final Vector2D expected = Vector2D.of(
+                        rotated.getX() + (rotated.getY() * shear.getX()),
+                        rotated.getY() + (rotated.getX() * shear.getY())
+                    );
+
+            Assertions.assertEquals(expected.getX(), transform.applyX(x, y), EPS);
+            Assertions.assertEquals(expected.getY(), transform.applyY(x, y), EPS);
+        });
+    }
+
+    @Test
     public void testApplyVector_identity() {
         // arrange
         final AffineTransformMatrix2D transform = AffineTransformMatrix2D.identity();
@@ -770,6 +800,27 @@ public class AffineTransformMatrix2DTest {
             final Vector2D expected = transform.apply(p1).subtract(transform.apply(p2));
 
             EuclideanTestUtils.assertCoordinatesEqual(expected, transform.applyVector(input), EPS);
+        });
+    }
+
+    @Test
+    public void testApplyVectorXY() {
+        // arrange
+        final Vector2D p1 = Vector2D.of(2, 3);
+
+        final AffineTransformMatrix2D transform = AffineTransformMatrix2D.identity()
+                .scale(1.5)
+                .translate(4, 6)
+                .rotate(0.3 * Math.PI);
+
+        // act/assert
+        runWithCoordinates((x, y) -> {
+            final Vector2D p2 = p1.add(Vector2D.of(x, y));
+
+            final Vector2D expected = transform.apply(p1).vectorTo(transform.apply(p2));
+
+            Assertions.assertEquals(expected.getX(), transform.applyVectorX(x, y), EPS);
+            Assertions.assertEquals(expected.getY(), transform.applyVectorY(x, y), EPS);
         });
     }
 

--- a/commons-geometry-examples/examples-jmh/src/main/java/org/apache/commons/geometry/examples/jmh/BenchmarkUtils.java
+++ b/commons-geometry-examples/examples-jmh/src/main/java/org/apache/commons/geometry/examples/jmh/BenchmarkUtils.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.geometry.examples.jmh;
+
+import org.apache.commons.rng.UniformRandomProvider;
+
+/** Class containing static utility methods for performance benchmarks.
+ */
+public final class BenchmarkUtils {
+
+    /** Utility class; no instantiation. */
+    private BenchmarkUtils() {}
+
+    /** Creates a random double number with a random sign and mantissa and a large range for
+     * the exponent. The numbers will not be uniform over the range.
+     * @param rng random number generator
+     * @return the random number
+     */
+    public static double randomDouble(final UniformRandomProvider rng) {
+        // Create random doubles using random bits in the sign bit and the mantissa.
+        // Then create an exponent in the range -64 to 64. Thus the sum product
+        // of 4 max or min values will not over or underflow.
+        final long mask = ((1L << 52) - 1) | 1L << 63;
+        final long bits = rng.nextLong() & mask;
+        // The exponent must be unsigned so + 1023 to the signed exponent
+        final long exp = rng.nextInt(129) - 64 + 1023;
+        return Double.longBitsToDouble(bits | (exp << 52));
+    }
+
+    /** Create an array of doubles populated using {@link #randomDouble(UniformRandomProvider)}.
+     * @param rng uniform random provider
+     * @param len array length
+     * @return array containing {@code len} random doubles
+     */
+    public static double[] randomDoubleArray(final UniformRandomProvider rng, final int len) {
+        final double[] arr = new double[len];
+
+        for (int i = 0; i < arr.length; ++i) {
+            arr[i] = randomDouble(rng);
+        }
+
+        return arr;
+    }
+}

--- a/commons-geometry-examples/examples-jmh/src/main/java/org/apache/commons/geometry/examples/jmh/euclidean/AffineTransformMatrixPerformance.java
+++ b/commons-geometry-examples/examples-jmh/src/main/java/org/apache/commons/geometry/examples/jmh/euclidean/AffineTransformMatrixPerformance.java
@@ -1,0 +1,386 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.geometry.examples.jmh.euclidean;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.geometry.euclidean.oned.AffineTransformMatrix1D;
+import org.apache.commons.geometry.euclidean.oned.Vector1D;
+import org.apache.commons.geometry.euclidean.threed.AffineTransformMatrix3D;
+import org.apache.commons.geometry.euclidean.threed.Vector3D;
+import org.apache.commons.geometry.euclidean.twod.AffineTransformMatrix2D;
+import org.apache.commons.geometry.euclidean.twod.Vector2D;
+import org.apache.commons.geometry.examples.jmh.BenchmarkUtils;
+import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.simple.RandomSource;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/** Benchmarks for
+ * {@link org.apache.commons.geometry.euclidean.AbstractAffineTransformMatrix AbstractAffineTransformMatrix}
+ * subclasses.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1, jvmArgs = {"-server", "-Xms512M", "-Xmx512M"})
+public class AffineTransformMatrixPerformance {
+
+    /** Input class providing random arrays of double values for transformation.
+     */
+    @State(Scope.Thread)
+    public static class TransformArrayInput {
+
+        /** The number of elements in the input array. */
+        @Param({"6000", "600000"})
+        private int size;
+
+        /** Array containing the input elements. */
+        private double[] array;
+
+        /** Get the configured size of the input array.
+         * @return the configured size of the input array
+         */
+        public int getSize() {
+            return size;
+        }
+
+        /** Get the input array.
+         * @return input array
+         */
+        public double[] getArray() {
+            return array;
+        }
+
+        /** Set up the input array.
+         */
+        @Setup(Level.Iteration)
+        public void setup() {
+            final UniformRandomProvider rand = RandomSource.create(RandomSource.XO_RO_SHI_RO_128_PP);
+
+            array = new double[size];
+
+            for (int i = 0; i < array.length; ++i) {
+                array[i] = BenchmarkUtils.randomDouble(rand);
+            }
+        }
+    }
+
+    /** Input class providing a 1D transform matrix.
+     */
+    @State(Scope.Thread)
+    public static class TransformMatrixInput1D {
+
+        /** Input transform matrix. */
+        private AffineTransformMatrix1D transform;
+
+        /** Get the input transform matrix.
+         * @return the input transform matrix
+         */
+        public AffineTransformMatrix1D getTransform() {
+            return transform;
+        }
+
+        /** Set up the input. */
+        @Setup
+        public void setup() {
+            final UniformRandomProvider rand = RandomSource.create(RandomSource.XO_RO_SHI_RO_128_PP);
+
+            transform = AffineTransformMatrix1D.of(BenchmarkUtils.randomDoubleArray(rand, 2));
+        }
+    }
+
+    /** Input class providing a 2D transform matrix.
+     */
+    @State(Scope.Thread)
+    public static class TransformMatrixInput2D {
+
+        /** Input transform matrix. */
+        private AffineTransformMatrix2D transform;
+
+        /** Get the input transform matrix.
+         * @return the input transform matrix
+         */
+        public AffineTransformMatrix2D getTransform() {
+            return transform;
+        }
+
+        /** Set up the input. */
+        @Setup
+        public void setup() {
+            final UniformRandomProvider rand = RandomSource.create(RandomSource.XO_RO_SHI_RO_128_PP);
+
+            transform = AffineTransformMatrix2D.of(BenchmarkUtils.randomDoubleArray(rand, 6));
+        }
+    }
+
+    /** Input class providing a 3D transform matrix.
+     */
+    @State(Scope.Thread)
+    public static class TransformMatrixInput3D {
+
+        /** Input transform matrix. */
+        private AffineTransformMatrix3D transform;
+
+        /** Get the input transform matrix.
+         * @return the input transform matrix
+         */
+        public AffineTransformMatrix3D getTransform() {
+            return transform;
+        }
+
+        /** Set up the input. */
+        @Setup
+        public void setup() {
+            final UniformRandomProvider rand = RandomSource.create(RandomSource.XO_RO_SHI_RO_128_PP);
+
+            transform = AffineTransformMatrix3D.of(BenchmarkUtils.randomDoubleArray(rand, 12));
+        }
+    }
+
+    /** Baseline benchmark for 1D transforms on array data.
+     * @param arrayInput array input
+     * @return transformed output
+     */
+    @Benchmark
+    public double[] baselineArray1D(final TransformArrayInput arrayInput) {
+        final double[] arr = arrayInput.getArray();
+
+        double x;
+        for (int i = 0; i < arr.length; ++i) {
+            x = arr[i];
+
+            arr[i] = x + 1;
+        }
+
+        return arr;
+    }
+
+    /** Benchmark testing the performance of transforming an array of doubles by converting each group
+     * to a Vector1D.
+     * @param arrayInput array input
+     * @param transformInput transform input
+     * @return transformed output
+     */
+    @Benchmark
+    public double[] transformArrayAsVectors1D(final TransformArrayInput arrayInput,
+            final TransformMatrixInput1D transformInput) {
+        final double[] arr = arrayInput.getArray();
+        final AffineTransformMatrix1D t = transformInput.getTransform();
+
+        Vector1D in;
+        Vector1D out;
+        for (int i = 0; i < arr.length; ++i) {
+            in = Vector1D.of(arr[i]);
+
+            out = t.apply(in);
+
+            arr[i] = out.getX();
+        }
+
+        return arr;
+    }
+
+    /** Benchmark testing the performance of transforming an array of doubles by transforming
+     * the components directly.
+     * @param arrayInput array input
+     * @param transformInput transform input
+     * @return transformed output
+     */
+    @Benchmark
+    public double[] transformArrayComponents1D(final TransformArrayInput arrayInput,
+            final TransformMatrixInput1D transformInput) {
+        final double[] arr = arrayInput.getArray();
+        final AffineTransformMatrix1D t = transformInput.getTransform();
+
+        double x;
+        for (int i = 0; i < arr.length; ++i) {
+            x = arr[i];
+
+            arr[i] = t.applyX(x);
+        }
+
+        return arr;
+    }
+
+    /** Baseline benchmark for 2D transforms on array data.
+     * @param arrayInput array input
+     * @return transformed output
+     */
+    @Benchmark
+    public double[] baselineArray2D(final TransformArrayInput arrayInput) {
+        final double[] arr = arrayInput.getArray();
+
+        double x;
+        double y;
+        for (int i = 0; i < arr.length; i += 2) {
+            x = arr[i];
+            y = arr[i + 1];
+
+            arr[i] = x + 1;
+            arr[i + 1] = y + 1;
+        }
+
+        return arr;
+    }
+
+    /** Benchmark testing the performance of transforming an array of doubles by converting each group
+     * to a Vector2D.
+     * @param arrayInput array input
+     * @param transformInput transform input
+     * @return transformed output
+     */
+    @Benchmark
+    public double[] transformArrayAsVectors2D(final TransformArrayInput arrayInput,
+            final TransformMatrixInput2D transformInput) {
+        final double[] arr = arrayInput.getArray();
+        final AffineTransformMatrix2D t = transformInput.getTransform();
+
+        Vector2D in;
+        Vector2D out;
+        for (int i = 0; i < arr.length; i += 2) {
+            in = Vector2D.of(
+                    arr[i],
+                    arr[i + 1]);
+
+            out = t.apply(in);
+
+            arr[i] = out.getX();
+            arr[i + 1] = out.getY();
+        }
+
+        return arr;
+    }
+
+    /** Benchmark testing the performance of transforming an array of doubles by transforming
+     * the components directly.
+     * @param arrayInput array input
+     * @param transformInput transform input
+     * @return transformed output
+     */
+    @Benchmark
+    public double[] transformArrayComponents2D(final TransformArrayInput arrayInput,
+            final TransformMatrixInput2D transformInput) {
+        final double[] arr = arrayInput.getArray();
+        final AffineTransformMatrix2D t = transformInput.getTransform();
+
+        double x;
+        double y;
+        for (int i = 0; i < arr.length; i += 2) {
+            x = arr[i];
+            y = arr[i + 1];
+
+            arr[i] = t.applyX(x, y);
+            arr[i + 1] = t.applyY(x, y);
+        }
+
+        return arr;
+    }
+
+    /** Baseline benchmark for 3D transforms on array data.
+     * @param arrayInput array input
+     * @return transformed output
+     */
+    @Benchmark
+    public double[] baselineArray3D(final TransformArrayInput arrayInput) {
+        final double[] arr = arrayInput.getArray();
+
+        double x;
+        double y;
+        double z;
+        for (int i = 0; i < arr.length; i += 3) {
+            x = arr[i];
+            y = arr[i + 1];
+            z = arr[i + 2];
+
+            arr[i] = x + 1;
+            arr[i + 1] = y + 1;
+            arr[i + 2] = z + 1;
+        }
+
+        return arr;
+    }
+
+    /** Benchmark testing the performance of transforming an array of doubles by converting each group
+     * to a Vector3D.
+     * @param arrayInput array input
+     * @param transformInput transform input
+     * @return transformed output
+     */
+    @Benchmark
+    public double[] transformArrayAsVectors3D(final TransformArrayInput arrayInput,
+            final TransformMatrixInput3D transformInput) {
+        final double[] arr = arrayInput.getArray();
+        final AffineTransformMatrix3D t = transformInput.getTransform();
+
+        Vector3D in;
+        Vector3D out;
+        for (int i = 0; i < arr.length; i += 3) {
+            in = Vector3D.of(
+                    arr[i],
+                    arr[i + 1],
+                    arr[i + 2]);
+
+            out = t.apply(in);
+
+            arr[i] = out.getX();
+            arr[i + 1] = out.getY();
+            arr[i + 2] = out.getZ();
+        }
+
+        return arr;
+    }
+
+    /** Benchmark testing the performance of transforming an array of doubles by transforming
+     * the components directly.
+     * @param arrayInput array input
+     * @param transformInput transform input
+     * @return transformed output
+     */
+    @Benchmark
+    public double[] transformArrayComponents3D(final TransformArrayInput arrayInput,
+            final TransformMatrixInput3D transformInput) {
+        final double[] arr = arrayInput.getArray();
+        final AffineTransformMatrix3D t = transformInput.getTransform();
+
+        double x;
+        double y;
+        double z;
+        for (int i = 0; i < arr.length; i += 3) {
+            x = arr[i];
+            y = arr[i + 1];
+            z = arr[i + 2];
+
+            arr[i] = t.applyX(x, y, z);
+            arr[i + 1] = t.applyY(x, y, z);
+            arr[i + 2] = t.applyZ(x, y, z);
+        }
+
+        return arr;
+    }
+}

--- a/commons-geometry-examples/examples-jmh/src/main/java/org/apache/commons/geometry/examples/jmh/euclidean/VectorPerformance.java
+++ b/commons-geometry-examples/examples-jmh/src/main/java/org/apache/commons/geometry/examples/jmh/euclidean/VectorPerformance.java
@@ -28,6 +28,7 @@ import org.apache.commons.geometry.core.Vector;
 import org.apache.commons.geometry.euclidean.oned.Vector1D;
 import org.apache.commons.geometry.euclidean.threed.Vector3D;
 import org.apache.commons.geometry.euclidean.twod.Vector2D;
+import org.apache.commons.geometry.examples.jmh.BenchmarkUtils;
 import org.apache.commons.rng.UniformRandomProvider;
 import org.apache.commons.rng.sampling.distribution.ZigguratNormalizedGaussianSampler;
 import org.apache.commons.rng.simple.RandomSource;
@@ -144,7 +145,7 @@ public class VectorPerformance {
         private DoubleSupplier createDoubleSupplier(final String type, final UniformRandomProvider rng) {
             switch (type) {
             case RANDOM:
-                return () -> createRandomDouble(rng);
+                return () -> BenchmarkUtils.randomDouble(rng);
             case NORMALIZABLE:
                 final ZigguratNormalizedGaussianSampler sampler = ZigguratNormalizedGaussianSampler.of(rng);
                 return () -> {
@@ -274,22 +275,6 @@ public class VectorPerformance {
         public String getType() {
             return NORMALIZABLE;
         }
-    }
-
-    /** Creates a random double number with a random sign and mantissa and a large range for
-     * the exponent. The numbers will not be uniform over the range.
-     * @param rng random number generator
-     * @return the random number
-     */
-    private static double createRandomDouble(final UniformRandomProvider rng) {
-        // Create random doubles using random bits in the sign bit and the mantissa.
-        // Then create an exponent in the range -64 to 64. Thus the sum product
-        // of 4 max or min values will not over or underflow.
-        final long mask = ((1L << 52) - 1) | 1L << 63;
-        final long bits = rng.nextLong() & mask;
-        // The exponent must be unsigned so + 1023 to the signed exponent
-        final long exp = rng.nextInt(129) - 64 + 1023;
-        return Double.longBitsToDouble(bits | (exp << 52));
     }
 
     /** Run a benchmark test on a function that produces a double.


### PR DESCRIPTION
Adding component-specific transform methods to AffineTransformMatrixXD classes, ex: AffineTransformMatrix3D.applyX().