### PR TITLE
Improve existing JavaDoc: highlight 'null' via {@code}

### DIFF
--- a/commons-geometry-core/src/main/java/org/apache/commons/geometry/core/ConvexHull.java
+++ b/commons-geometry-core/src/main/java/org/apache/commons/geometry/core/ConvexHull.java
@@ -31,10 +31,10 @@ public interface ConvexHull<P extends Point<P>> {
     List<P> getVertices();
 
     /** Return the region representing the convex hull. This will return
-     * null in cases where the hull does not define a region with non-zero
+     * {@code null} in cases where the hull does not define a region with non-zero
      * size, such as when only a single unique point exists or when all points
      * are collinear.
-     * @return the region representing by the convex hull or null if the
+     * @return the region representing by the convex hull or {@code null} if the
      *      convex hull does not define a region of non-zero size
      */
     Region<P> getRegion();

--- a/commons-geometry-core/src/main/java/org/apache/commons/geometry/core/Region.java
+++ b/commons-geometry-core/src/main/java/org/apache/commons/geometry/core/Region.java
@@ -42,7 +42,7 @@ public interface Region<P extends Point<P>> extends Sized {
      */
     double getBoundarySize();
 
-    /** Get the centroid, or geometric center, of the region or null if no centroid
+    /** Get the centroid, or geometric center, of the region or {@code null} if no centroid
      * exists or one exists but is not unique. A centroid will not exist for empty or
      * infinite regions.
      *
@@ -51,7 +51,7 @@ public interface Region<P extends Point<P>> extends Sized {
      * lying on the boundary. If a physical object has a uniform density, then its center
      * of mass is the same as its geometric centroid.
      * </p>
-     * @return the centroid of the region or null if no unique centroid exists
+     * @return the centroid of the region or {@code null} if no unique centroid exists
      * @see <a href="https://en.wikipedia.org/wiki/Centroid">Centroid</a>
      */
     P getCentroid();
@@ -72,11 +72,11 @@ public interface Region<P extends Point<P>> extends Sized {
         return location != null && location != RegionLocation.OUTSIDE;
     }
 
-    /** Project a point onto the boundary of the region. Null is returned if
+    /** Project a point onto the boundary of the region. {@code null} is returned if
      * the region contains no boundaries (ie, is either {@link #isFull() full}
      * or {@link #isEmpty() empty}).
      * @param pt pt to project
-     * @return projection of the point on the boundary of the region or null
+     * @return projection of the point on the boundary of the region or {@code null}
      *      if the region does not contain any boundaries
      */
     P project(P pt);

--- a/commons-geometry-core/src/main/java/org/apache/commons/geometry/core/Vector.java
+++ b/commons-geometry-core/src/main/java/org/apache/commons/geometry/core/Vector.java
@@ -99,10 +99,10 @@ public interface Vector<V extends Vector<V>> extends Spatial {
      */
     V normalize();
 
-    /** Attempt to compute a normalized vector aligned with the instance, returning null if
+    /** Attempt to compute a normalized vector aligned with the instance, returning {@code null} if
      * such a vector cannot be computed. This method is equivalent to {@link #normalize()}
      * but returns null instead of throwing an exception on failure.
-     * @return normalized vector or null if such a vector cannot be computed, i.e. if the
+     * @return normalized vector or {@code null} if such a vector cannot be computed, i.e. if the
      *      norm is zero, NaN, or infinite
      * @see #normalize()
      */

--- a/commons-geometry-core/src/main/java/org/apache/commons/geometry/core/collection/PointMap.java
+++ b/commons-geometry-core/src/main/java/org/apache/commons/geometry/core/collection/PointMap.java
@@ -43,7 +43,7 @@ public interface PointMap<P extends Point<P>, V> extends Map<P, V> {
      * the {@link Entry#setValue(Object)} method to modify the
      * mapping.
      * @param pt point to fetch the map entry for
-     * @return map entry for the given point or null if no such entry
+     * @return map entry for the given point or {@code null} if no such entry
      *      exists
      */
     Entry<P, V> getEntry(P pt);

--- a/commons-geometry-core/src/main/java/org/apache/commons/geometry/core/collection/PointSet.java
+++ b/commons-geometry-core/src/main/java/org/apache/commons/geometry/core/collection/PointSet.java
@@ -37,10 +37,10 @@ import org.apache.commons.geometry.core.Point;
  */
 public interface PointSet<P extends Point<P>> extends Set<P> {
 
-    /** Get the element equivalent to {@code pt} or null if no
+    /** Get the element equivalent to {@code pt} or {@code null} if no
      * such an element exists.
      * @param pt point to find an equivalent for
-     * @return set entry equivalent to {@code pt} or null if
+     * @return set entry equivalent to {@code pt} or {@code null} if
      *      no such entry exists
      */
     P get(P pt);

--- a/commons-geometry-core/src/main/java/org/apache/commons/geometry/core/internal/AbstractBucketPointMap.java
+++ b/commons-geometry-core/src/main/java/org/apache/commons/geometry/core/internal/AbstractBucketPointMap.java
@@ -74,7 +74,7 @@ public abstract class AbstractBucketPointMap<P extends Point<P>, V>
 
         /** Create a new {@link BucketNode} instance.
          * @param map owning map
-         * @param parent parent node; will be null for the tree root
+         * @param parent parent node; will be {@code null} for the tree root
          * @param childIndex index of the new node in its parent child list; will be {@code -1}
          *      if the new node does not have a parent
          * @return the newly created node
@@ -286,7 +286,7 @@ public abstract class AbstractBucketPointMap<P extends Point<P>, V>
     protected abstract int disambiguatePointComparison(P a, P b);
 
     /** Construct a new node instance.
-     * @param parent parent node; will be null for the tree root
+     * @param parent parent node; will be {@code null} for the tree root
      * @param childIndex index of the node in its parent child list
      * @return the new node instance
      */
@@ -332,19 +332,19 @@ public abstract class AbstractBucketPointMap<P extends Point<P>, V>
         return Arrays.asList(new BucketNode[nodeChildCount]);
     }
 
-    /** Get the entry for the given key or null if not found.
+    /** Get the entry for the given key or {@code null} if not found.
      * @param key key to search for
-     * @return entry for the given key or null if not found
+     * @return entry for the given key or {@code null} if not found
      */
     @SuppressWarnings("unchecked")
     private Entry<P, V> findEntry(final Object key) {
         return findEntryByPoint((P) key);
     }
 
-    /** Find the entry for the given point or null if one does not
+    /** Find the entry for the given point or {@code null} if one does not
      * exist.
      * @param pt point to find the entry for
-     * @return entry for the given point or null if one does not exist
+     * @return entry for the given point or {@code null} if one does not exist
      */
     private Entry<P, V> findEntryByPoint(final P pt) {
         Entry<P, V> entry = null;
@@ -357,10 +357,10 @@ public abstract class AbstractBucketPointMap<P extends Point<P>, V>
         return entry;
     }
 
-    /** Remove and return the entry for the given point or null
+    /** Remove and return the entry for the given point or {@code null}
      * if no such entry exists.
      * @param pt point to remove the entry for
-     * @return the removed entry or null if not found
+     * @return the removed entry or {@code null} if not found
      */
     private Entry<P, V> removeEntryByPoint(final P pt) {
         Entry<P, V> entry = null;
@@ -402,8 +402,8 @@ public abstract class AbstractBucketPointMap<P extends Point<P>, V>
     }
 
     /** Get the argument with the smallest distance value.
-     * @param a first entry; may be null
-     * @param b second entry; may be null
+     * @param a first entry; may be {@code null}
+     * @param b second entry; may be {@code null}
      * @return argument with the smallest distance value
      */
     private DistancedValue<Entry<P, V>> getNearest(
@@ -415,8 +415,8 @@ public abstract class AbstractBucketPointMap<P extends Point<P>, V>
     }
 
     /** Get the argument with the largest distance value.
-     * @param a first entry; may be null
-     * @param b second entry; may be null
+     * @param a first entry; may be {@code null}
+     * @param b second entry; may be {@code null}
      * @return argument with the largest distance value
      */
     private DistancedValue<Entry<P, V>> getFarthest(
@@ -427,11 +427,11 @@ public abstract class AbstractBucketPointMap<P extends Point<P>, V>
                 b;
     }
 
-    /** Compare two entries with distance values. If either entry is null, the distance
+    /** Compare two entries with distance values. If either entry is {@code null}, the distance
      * for that entry is taken to be {@code nullDistance}.
-     * @param a first entry; may be null
-     * @param b second entry; may be null
-     * @param nullDistance distance used for null arguments
+     * @param a first entry; may be {@code null}
+     * @param b second entry; may be {@code null}
+     * @param nullDistance distance used for {@code null} arguments
      * @return integer comparison result
      */
     private int compareEntries(
@@ -463,8 +463,8 @@ public abstract class AbstractBucketPointMap<P extends Point<P>, V>
     /** Return the value for the argument or {@code null} if {@code entry}
      * is {@code null}.
      * @param <V> Value type
-     * @param entry entry to return the value for; may be null
-     * @return value for the argument or null if the argument is null
+     * @param entry entry to return the value for; may be {@code null}
+     * @return value for the argument or {@code null} if the argument is {@code null}
      */
     private static <V> V getValue(final Entry<?, V> entry) {
         return entry != null ?
@@ -489,10 +489,10 @@ public abstract class AbstractBucketPointMap<P extends Point<P>, V>
         /** Index of this node in its parent child list. */
         private int childIndex;
 
-        /** Child nodes; elements may be null. */
+        /** Child nodes; elements may be {@code null}. */
         private List<BucketNode<P, V>> children;
 
-        /** Entries stored in the node; will be null for non-leaf nodes. */
+        /** Entries stored in the node; will be {@code null} for non-leaf nodes. */
         private List<Entry<P, V>> entries;
 
         /** Number of entries in this subtree. */
@@ -500,7 +500,7 @@ public abstract class AbstractBucketPointMap<P extends Point<P>, V>
 
         /** Construct a new instance.
          * @param map owning map
-         * @param parent parent node or null if the tree root
+         * @param parent parent node or {@code null} if the tree root
          * @param childIndex index of this node in its parent, or {@code -1}
          *      if no parent exists
          */
@@ -552,7 +552,7 @@ public abstract class AbstractBucketPointMap<P extends Point<P>, V>
 
         /** Find and return the map entry matching the given key.
          * @param key point key
-         * @return entry matching the given key or null if not found
+         * @return entry matching the given key or {@code null} if not found
          */
         public Entry<P, V> findEntry(final P key) {
             if (isLeaf()) {
@@ -573,7 +573,7 @@ public abstract class AbstractBucketPointMap<P extends Point<P>, V>
         /** Find and return the map entry matching the given key in the node's children.
          * This method must only be called on internal nodes.
          * @param key point key
-         * @return entry matching the given key or null if not found
+         * @return entry matching the given key or {@code null} if not found
          */
         private Entry<P, V> findEntryInChildren(final P key) {
             final int loc = getSearchLocation(key);
@@ -588,9 +588,9 @@ public abstract class AbstractBucketPointMap<P extends Point<P>, V>
             return null;
         }
 
-        /** Find the first entry in the tree with the given value or null if not found.
+        /** Find the first entry in the tree with the given value or {@code null} if not found.
          * @param value value to search for
-         * @return the first entry in the tree with the given value or null if not found
+         * @return the first entry in the tree with the given value or {@code null} if not found
          */
         public Entry<P, V> findEntryByValue(final Object value) {
             if (isLeaf()) {
@@ -607,10 +607,10 @@ public abstract class AbstractBucketPointMap<P extends Point<P>, V>
             return findEntryByValueInChildren(value);
         }
 
-        /** Find the first entry in the child subtrees for this node with the given value or null
+        /** Find the first entry in the child subtrees for this node with the given value or {@code null}
          * if not found. This method must only be called on internal nodes.
          * @param value value to search for
-         * @return the first entry in the child subtrees with the given value or null if not found
+         * @return the first entry in the child subtrees with the given value or {@code null} if not found
          */
         private Entry<P, V> findEntryByValueInChildren(final Object value) {
             for (final BucketNode<P, V> child : children) {
@@ -657,7 +657,7 @@ public abstract class AbstractBucketPointMap<P extends Point<P>, V>
 
         /** Remove the given key, returning the previously mapped entry.
          * @param key key to remove
-         * @return the value previously mapped to the key or null if no
+         * @return the value previously mapped to the key or {@code null} if no
          *       value was mapped
          */
         public Entry<P, V> removeEntry(final P key) {
@@ -686,7 +686,7 @@ public abstract class AbstractBucketPointMap<P extends Point<P>, V>
         /** Remove the given key from the node's child subtrees, returning the previously
          * mapped entry. This method must only be called on internal nodes.
          * @param key key to remove
-         * @return the value previously mapped to the key or null if no
+         * @return the value previously mapped to the key or {@code null} if no
          *       value was mapped
          */
         private Entry<P, V> removeEntryFromChildren(final P key) {
@@ -705,10 +705,10 @@ public abstract class AbstractBucketPointMap<P extends Point<P>, V>
             return null;
         }
 
-        /** Find the nearest entry to {@code refPt} in the subtree rooted at this node, or null if
+        /** Find the nearest entry to {@code refPt} in the subtree rooted at this node, or {@code null} if
          * the subtree is empty.
          * @param refPt reference point
-         * @return nearest entry to {@code refPt} in the subtree rooted at this node, or null if no
+         * @return nearest entry to {@code refPt} in the subtree rooted at this node, or {@code null} if no
          *      such entry exists
          */
         public DistancedValue<Entry<P, V>> findNearestEntry(final P refPt) {
@@ -716,11 +716,11 @@ public abstract class AbstractBucketPointMap<P extends Point<P>, V>
         }
 
         /** Find the nearest entry to {@code refPt} within the maximum distance specified in the subtree
-         * rooted at this node, or null if no such entry exists.
+         * rooted at this node, or {@code null} if no such entry exists.
          * @param refPt reference point
          * @param maxDist maximum search distance
          * @return nearest entry to {@code refPt} within the maximum distance specified in the subtree
-         *      rooted at this node, or null if no such entry exists.
+         *      rooted at this node, or {@code null} if no such entry exists.
          */
         private DistancedValue<Entry<P, V>> findNearestEntry(final P refPt, final double maxDist) {
             if (isLeaf()) {
@@ -745,12 +745,12 @@ public abstract class AbstractBucketPointMap<P extends Point<P>, V>
         }
 
         /** Find the nearest entry to {@code refPt} within the maximum distance specified in the child subtrees
-         * rooted at this node, or null if no such entry exists. This method must only be call on internal
+         * rooted at this node, or {@code null} if no such entry exists. This method must only be call on internal
          * nodes.
          * @param refPt reference point
          * @param maxDist maximum search distance
          * @return nearest entry to {@code refPt} within the maximum distance specified in the subtree
-         *      rooted at this node, or null if no such entry exists.
+         *      rooted at this node, or {@code null} if no such entry exists.
          */
         private DistancedValue<Entry<P, V>> findNearestEntryInChildren(final P refPt, final double maxDist) {
             // look through children in order of increasing minimum distance from the
@@ -788,7 +788,7 @@ public abstract class AbstractBucketPointMap<P extends Point<P>, V>
 
         /** Find the farthest entry from {@code refPt} within the subtree rooted at this node.
          * @param refPt reference point
-         * @return farthest entry from {@code refPt} in the subtree rooted at this node, or null
+         * @return farthest entry from {@code refPt} in the subtree rooted at this node, or {@code null}
          *      if no such entry exists.
          */
         public DistancedValue<Entry<P, V>> findFarthestEntry(final P refPt) {
@@ -1054,8 +1054,8 @@ public abstract class AbstractBucketPointMap<P extends Point<P>, V>
             entries = null;
         }
 
-        /** Get the parent node or null if one does not exist.
-         * @return parent node or null if one does not exist.
+        /** Get the parent node or {@code null} if one does not exist.
+         * @return parent node or {@code null} if one does not exist.
          */
         protected BucketNode<P, V> getParent() {
             return parent;
@@ -1068,10 +1068,10 @@ public abstract class AbstractBucketPointMap<P extends Point<P>, V>
             return map.precision;
         }
 
-        /** Get the given entry in the child at {@code idx} or null if not found.
+        /** Get the given entry in the child at {@code idx} or {@code null} if not found.
          * @param idx child index
          * @param key key to search for
-         * @return entry matching {@code key} in child or null if not found
+         * @return entry matching {@code key} in child or {@code null} if not found
          */
         private Entry<P, V> getEntryInChild(final int idx, final P key) {
             final BucketNode<P, V> child = children.get(idx);
@@ -1084,7 +1084,7 @@ public abstract class AbstractBucketPointMap<P extends Point<P>, V>
         /** Remove the given key from the child at {@code idx}.
          * @param idx index of the child
          * @param key key to remove
-         * @return entry removed from the child or null if not found
+         * @return entry removed from the child or {@code null} if not found
          */
         private Entry<P, V> removeFromChild(final int idx, final P key) {
             final BucketNode<P, V> child = children.get(idx);
@@ -1340,7 +1340,7 @@ public abstract class AbstractBucketPointMap<P extends Point<P>, V>
         /** Find the next map entry iterator recursively in the subtree rooted at {@code node}.
          * @param node root of the subtree to obtain an iterator in
          * @param offset index offset of the first entry in the subtree
-         * @return the next map entry iterator or null if no leaf nodes in the subtree contain the
+         * @return the next map entry iterator or {@code null} if no leaf nodes in the subtree contain the
          *      entry at {@code nextIdx}
          */
         private Iterator<Entry<P, V>> findIteratorRecursive(final BucketNode<P, V> node, final int offset) {
@@ -1358,7 +1358,7 @@ public abstract class AbstractBucketPointMap<P extends Point<P>, V>
         /** Find the next map entry iterator in the children of {@code node}.
          * @param node root of the subtree to obtain an iterator in
          * @param offset index offset of the first entry in the subtree
-         * @return the next map entry iterator or null if no leaf nodes in the subtree contain the
+         * @return the next map entry iterator or {@code null} if no leaf nodes in the subtree contain the
          *      entry at {@code nextIdx}
          */
         private Iterator<Entry<P, V>> findIteratorInNodeChildren(final BucketNode<P, V> node, final int offset) {

--- a/commons-geometry-core/src/main/java/org/apache/commons/geometry/core/internal/AbstractPointMap1D.java
+++ b/commons-geometry-core/src/main/java/org/apache/commons/geometry/core/internal/AbstractPointMap1D.java
@@ -178,7 +178,7 @@ public abstract class AbstractPointMap1D<P extends Point<P>, V>
     /** Add or update the entry for the given key/value pair.
      * @param key entry key
      * @param value entry value
-     * @return the value of the previous entry for {@code key} or null
+     * @return the value of the previous entry for {@code key} or {@code null}
      *      if no such entry exists
      */
     protected abstract V putInternal(P key, V value);

--- a/commons-geometry-core/src/main/java/org/apache/commons/geometry/core/internal/GeometryInternalUtils.java
+++ b/commons-geometry-core/src/main/java/org/apache/commons/geometry/core/internal/GeometryInternalUtils.java
@@ -43,7 +43,7 @@ public final class GeometryInternalUtils {
      * @param <P> Point type
      * @param pt point to check
      * @return point given as the argument
-     * @throws NullPointerException if the point is null
+     * @throws NullPointerException if the point is {@code null}
      * @throws IllegalArgumentException if the point is not finite
      */
     public static <P extends Point<P>> P requireFinite(final P pt) {

--- a/commons-geometry-core/src/main/java/org/apache/commons/geometry/core/internal/SimpleTupleFormat.java
+++ b/commons-geometry-core/src/main/java/org/apache/commons/geometry/core/internal/SimpleTupleFormat.java
@@ -37,17 +37,17 @@ public class SimpleTupleFormat {
     /** String separating tuple values. */
     private final String separator;
 
-    /** String used to signal the start of a tuple; may be null. */
+    /** String used to signal the start of a tuple; may be {@code null}. */
     private final String prefix;
 
-    /** String used to signal the end of a tuple; may be null. */
+    /** String used to signal the end of a tuple; may be {@code null}. */
     private final String suffix;
 
     /** Constructs a new instance with the default string separator (a comma)
      * and the given prefix and suffix.
-     * @param prefix String used to signal the start of a tuple; if null, no
+     * @param prefix String used to signal the start of a tuple; if {@code null}, no
      *      string is expected at the start of the tuple
-     * @param suffix String used to signal the end of a tuple; if null, no
+     * @param suffix String used to signal the end of a tuple; if {@code null}, no
      *      string is expected at the end of the tuple
      */
     public SimpleTupleFormat(final String prefix, final String suffix) {
@@ -56,9 +56,9 @@ public class SimpleTupleFormat {
 
     /** Simple constructor.
      * @param separator String used to separate tuple values; must not be null.
-     * @param prefix String used to signal the start of a tuple; if null, no
+     * @param prefix String used to signal the start of a tuple; if {@code null}, no
      *      string is expected at the start of the tuple
-     * @param suffix String used to signal the end of a tuple; if null, no
+     * @param suffix String used to signal the end of a tuple; if {@code null}, no
      *      string is expected at the end of the tuple
      */
     protected SimpleTupleFormat(final String separator, final String prefix, final String suffix) {
@@ -74,15 +74,15 @@ public class SimpleTupleFormat {
         return separator;
     }
 
-    /** Return the string used to signal the start of a tuple. This value may be null.
-     * @return the string used to begin each tuple or null
+    /** Return the string used to signal the start of a tuple. This value may be {@code null}.
+     * @return the string used to begin each tuple or {@code null}
      */
     public String getPrefix() {
         return prefix;
     }
 
-    /** Returns the string used to signal the end of a tuple. This value may be null.
-     * @return the string used to end each tuple or null
+    /** Returns the string used to signal the end of a tuple. This value may be {@code null}.
+     * @return the string used to end each tuple or {@code null}
      */
     public String getSuffix() {
         return suffix;
@@ -254,7 +254,7 @@ public class SimpleTupleFormat {
 
     /** Read the configured prefix from the current position in the given string, ignoring any preceding
      * whitespace, and advance the parsing position past the prefix sequence. An exception is thrown if the
-     * prefix is not found. Does nothing if the prefix is null.
+     * prefix is not found. Does nothing if the prefix is {@code null}.
      * @param str the string being parsed
      * @param pos the current parsing position
      * @throws IllegalArgumentException if the configured prefix is not null and is not found at the current
@@ -305,7 +305,7 @@ public class SimpleTupleFormat {
 
     /** Read the configured suffix from the current position in the given string, ignoring any preceding
      * whitespace, and advance the parsing position past the suffix sequence. An exception is thrown if the
-     * suffix is not found. Does nothing if the suffix is null.
+     * suffix is not found. Does nothing if the suffix is {@code null}.
      * @param str the string being parsed
      * @param pos the current parsing position
      * @throws IllegalArgumentException if the configured suffix is not null and is not found at the current

--- a/commons-geometry-core/src/main/java/org/apache/commons/geometry/core/partitioning/AbstractConvexHyperplaneBoundedRegion.java
+++ b/commons-geometry-core/src/main/java/org/apache/commons/geometry/core/partitioning/AbstractConvexHyperplaneBoundedRegion.java
@@ -123,9 +123,9 @@ public abstract class AbstractConvexHyperplaneBoundedRegion<P extends Point<P>, 
     }
 
     /** Trim the given hyperplane subset to the portion contained inside this instance.
-     * @param sub hyperplane subset to trim. Null is returned if the subset does not intersect the instance.
+     * @param sub hyperplane subset to trim. {@code null} is returned if the subset does not intersect the instance.
      * @return portion of the argument that lies entirely inside the region represented by
-     *      this instance, or null if it does not intersect.
+     *      this instance, or {@code null} if it does not intersect.
      */
     public HyperplaneConvexSubset<P> trim(final HyperplaneConvexSubset<P> sub) {
         HyperplaneConvexSubset<P> remaining = sub;

--- a/commons-geometry-core/src/main/java/org/apache/commons/geometry/core/partitioning/HyperplaneSubset.java
+++ b/commons-geometry-core/src/main/java/org/apache/commons/geometry/core/partitioning/HyperplaneSubset.java
@@ -65,7 +65,7 @@ public interface HyperplaneSubset<P extends Point<P>> extends Splittable<P, Hype
      */
     boolean isEmpty();
 
-    /** Get the centroid, or geometric center, of the hyperplane subset or null
+    /** Get the centroid, or geometric center, of the hyperplane subset or {@code null}
      * if no centroid exists or one exists but is not unique. A centroid will not
      * exist for empty or infinite subsets.
      *
@@ -74,7 +74,7 @@ public interface HyperplaneSubset<P extends Point<P>> extends Splittable<P, Hype
      * lying on the boundary. If a physical object has a uniform density, then its center
      * of mass is the same as its geometric centroid.
      * </p>
-     * @return the centroid of the hyperplane subset or null if no unique centroid exists
+     * @return the centroid of the hyperplane subset or {@code null} if no unique centroid exists
      * @see <a href="https://en.wikipedia.org/wiki/Centroid">Centroid</a>
      */
     P getCentroid();
@@ -106,11 +106,11 @@ public interface HyperplaneSubset<P extends Point<P>> extends Splittable<P, Hype
     }
 
     /** Return the closest point to the argument that is contained in the subset
-     * (ie, not classified as {@link RegionLocation#OUTSIDE outside}), or null if no
+     * (ie, not classified as {@link RegionLocation#OUTSIDE outside}), or {@code null} if no
      * such point exists.
      * @param pt the reference point
      * @return the closest point to the reference point that is contained in the subset,
-     *      or null if no such point exists
+     *      or {@code null} if no such point exists
      */
     P closest(P pt);
 

--- a/commons-geometry-core/src/main/java/org/apache/commons/geometry/core/partitioning/Split.java
+++ b/commons-geometry-core/src/main/java/org/apache/commons/geometry/core/partitioning/Split.java
@@ -31,9 +31,9 @@ public final class Split<T> {
 
     /** Build a new instance from its parts.
      * @param minus part of the object lying on the minus side of the
-     *      splitting hyperplane or null if no such part exists
+     *      splitting hyperplane or {@code null} if no such part exists
      * @param plus part of the object lying on the plus side of the
-     *      splitting hyperplane or null if no such part exists.
+     *      splitting hyperplane or {@code null} if no such part exists.
      */
     public Split(final T minus, final T plus) {
         this.minus = minus;
@@ -41,7 +41,7 @@ public final class Split<T> {
     }
 
     /** Get the part of the object lying on the minus side of the splitting
-     * hyperplane or null if no such part exists.
+     * hyperplane or {@code null} if no such part exists.
      * @return part of the object lying on the minus side of the splitting
      *      hyperplane
      */
@@ -50,7 +50,7 @@ public final class Split<T> {
     }
 
     /** Get the part of the object lying on the plus side of the splitting
-     * hyperplane or null if no such part exists.
+     * hyperplane or {@code null} if no such part exists.
      * @return part of the object lying on the plus side of the splitting
      *      hyperplane
      */

--- a/commons-geometry-core/src/main/java/org/apache/commons/geometry/core/partitioning/bsp/AbstractBSPTree.java
+++ b/commons-geometry-core/src/main/java/org/apache/commons/geometry/core/partitioning/bsp/AbstractBSPTree.java
@@ -509,7 +509,7 @@ public abstract class AbstractBSPTree<P extends Point<P>, N extends AbstractBSPT
      *
      * @param node the node representing the region to fit the hyperplane subset to
      * @param sub the hyperplane subset to trim to the node's region
-     * @return the trimmed hyperplane subset or null if the given hyperplane subset does not intersect
+     * @return the trimmed hyperplane subset or {@code null} if the given hyperplane subset does not intersect
      *      the node's region
      */
     protected HyperplaneConvexSubset<P> trimToNode(final N node, final HyperplaneConvexSubset<P> sub) {
@@ -824,18 +824,18 @@ public abstract class AbstractBSPTree<P extends Point<P>, N extends AbstractBSPT
         /** The owning tree instance. */
         private final AbstractBSPTree<P, N> tree;
 
-        /** The parent node; this will be null for the tree root node. */
+        /** The parent node; this will be {@code null} for the tree root node. */
         private N parent;
 
-        /** The hyperplane convex subset cutting the node's region; this will be null for leaf nodes. */
+        /** The hyperplane convex subset cutting the node's region; this will be {@code null} for leaf nodes. */
         private HyperplaneConvexSubset<P> cut;
 
-        /** The node lying on the minus side of the cut hyperplane; this will be null
+        /** The node lying on the minus side of the cut hyperplane; this will be {@code null}
          * for leaf nodes.
          */
         private N minus;
 
-        /** The node lying on the plus side of the cut hyperplane; this will be null
+        /** The node lying on the plus side of the cut hyperplane; this will be {@code null}
          * for leaf nodes.
          */
         private N plus;

--- a/commons-geometry-core/src/main/java/org/apache/commons/geometry/core/partitioning/bsp/AbstractRegionBSPTree.java
+++ b/commons-geometry-core/src/main/java/org/apache/commons/geometry/core/partitioning/bsp/AbstractRegionBSPTree.java
@@ -873,7 +873,7 @@ public abstract class AbstractRegionBSPTree<
             return a;
         }
 
-        /** Get the projected point on the region's boundary, or null if no point could be found.
+        /** Get the projected point on the region's boundary, or {@code null} if no point could be found.
          * @return the projected point on the region's boundary
          */
         public P getProjected() {
@@ -1068,7 +1068,7 @@ public abstract class AbstractRegionBSPTree<
         /** Recursively condense nodes that have children with homogenous location attributes
          * (eg, both inside, both outside) into single nodes.
          * @param node the root of the subtree to condense
-         * @return the location of the successfully condensed subtree or null if no condensing was
+         * @return the location of the successfully condensed subtree or {@code null} if no condensing was
          *      able to be performed
          */
         private RegionLocation condenseRecursive(final N node) {

--- a/commons-geometry-core/src/main/java/org/apache/commons/geometry/core/partitioning/bsp/BSPTree.java
+++ b/commons-geometry-core/src/main/java/org/apache/commons/geometry/core/partitioning/bsp/BSPTree.java
@@ -133,7 +133,7 @@ public interface BSPTree<P extends Point<P>, N extends BSPTree.Node<P, N>>
          */
         int depth();
 
-        /** Get the parent of the node. This will be null if the node is the
+        /** Get the parent of the node. This will be {@code null} if the node is the
          * root of the tree.
          * @return the parent node for this instance
          */
@@ -141,7 +141,7 @@ public interface BSPTree<P extends Point<P>, N extends BSPTree.Node<P, N>>
 
         /** Get the cut for the node. This is a hyperplane convex subset that splits
          * the region for the cell into two disjoint regions, namely the plus and
-         * minus regions. This will be null for leaf nodes.
+         * minus regions. This will be {@code null} for leaf nodes.
          * @see #getPlus()
          * @see #getMinus()
          * @return the cut for the cell
@@ -150,19 +150,19 @@ public interface BSPTree<P extends Point<P>, N extends BSPTree.Node<P, N>>
         HyperplaneConvexSubset<P> getCut();
 
         /** Get the hyperplane containing the node cut, if it exists.
-         * @return the hyperplane containing the node cut, or null if
+         * @return the hyperplane containing the node cut, or {@code null} if
          *      the node does not have a cut
          * @see #getCut()
          */
         Hyperplane<P> getCutHyperplane();
 
-        /** Get the node for the minus region of the cell. This will be null if the
+        /** Get the node for the minus region of the cell. This will be {@code null} if the
          * node has not been cut, ie if it is a leaf node.
          * @return the node for the minus region of the cell
          */
         N getMinus();
 
-        /** Get the node for the plus region of the cell. This will be null if the
+        /** Get the node for the plus region of the cell. This will be {@code null} if the
          * node has not been cut, ie if it is a leaf node.
          * @return the node for the plus region of the cell
          */
@@ -194,10 +194,10 @@ public interface BSPTree<P extends Point<P>, N extends BSPTree.Node<P, N>>
 
         /** Trim the given hyperplane subset to the region defined by this node by cutting
          * the argument with the cut hyperplanes (binary partitioners) of all parent nodes
-         * up to the root. Null is returned if the hyperplane subset lies outside of the region
+         * up to the root. {@code null} is returned if the hyperplane subset lies outside of the region
          * defined by the node.
          * @param sub the hyperplane subset to trim
-         * @return the trimmed hyperplane subset or null if no part of the argument lies
+         * @return the trimmed hyperplane subset or {@code null} if no part of the argument lies
          *      within the node's region
          */
         HyperplaneConvexSubset<P> trim(HyperplaneConvexSubset<P> sub);

--- a/commons-geometry-core/src/main/java/org/apache/commons/geometry/core/partitioning/bsp/BSPTreeVisitor.java
+++ b/commons-geometry-core/src/main/java/org/apache/commons/geometry/core/partitioning/bsp/BSPTreeVisitor.java
@@ -87,7 +87,7 @@ public interface BSPTreeVisitor<P extends Point<P>, N extends BSPTree.Node<P, N>
     Result visit(N node);
 
     /** Determine the visit order for the given internal node. This is called for each
-     * internal node before {@link #visit(BSPTree.Node)} is called. Returning null
+     * internal node before {@link #visit(BSPTree.Node)} is called. returning {@code null}
      * or {@link Order#NONE}from this method skips the subtree rooted at the given node.
      * This method is not called on leaf nodes.
      * @param internalNode the internal node to determine the visit order for

--- a/commons-geometry-core/src/main/java/org/apache/commons/geometry/core/partitioning/bsp/BSPTreeVisitor.java
+++ b/commons-geometry-core/src/main/java/org/apache/commons/geometry/core/partitioning/bsp/BSPTreeVisitor.java
@@ -87,8 +87,8 @@ public interface BSPTreeVisitor<P extends Point<P>, N extends BSPTree.Node<P, N>
     Result visit(N node);
 
     /** Determine the visit order for the given internal node. This is called for each
-     * internal node before {@link #visit(BSPTree.Node)} is called. returning {@code null}
-     * or {@link Order#NONE}from this method skips the subtree rooted at the given node.
+     * internal node before {@link #visit(BSPTree.Node)} is called. Returning {@code null}
+     * or {@link Order#NONE} from this method skips the subtree rooted at the given node.
      * This method is not called on leaf nodes.
      * @param internalNode the internal node to determine the visit order for
      * @return the order that the subtree rooted at the given node should be visited

--- a/commons-geometry-core/src/test/java/org/apache/commons/geometry/core/partitioning/test/TestLine.java
+++ b/commons-geometry-core/src/test/java/org/apache/commons/geometry/core/partitioning/test/TestLine.java
@@ -213,7 +213,7 @@ public final class TestLine implements EmbeddingHyperplane<TestPoint2D, TestPoin
     /** Get the intersection point of the instance and another line.
      * @param other other line
      * @return intersection point of the instance and the other line
-     *      or null if there is no unique intersection point (ie, the lines
+     *      or {@code null} if there is no unique intersection point (ie, the lines
      *      are parallel or coincident)
      */
     public TestPoint2D intersection(final TestLine other) {

--- a/commons-geometry-core/src/test/java/org/apache/commons/geometry/core/partitioning/test/TestLineSegmentCollection.java
+++ b/commons-geometry-core/src/test/java/org/apache/commons/geometry/core/partitioning/test/TestLineSegmentCollection.java
@@ -38,7 +38,7 @@ public final class TestLineSegmentCollection implements HyperplaneSubset<TestPoi
     /** Create a new instance with the given line segments. The segments
      * are all assumed to lie on the same hyperplane.
      * @param segments the segments to use in the collection
-     * @throws IllegalArgumentException if the collection is null or empty
+     * @throws IllegalArgumentException if the collection is {@code null} or empty
      */
     public TestLineSegmentCollection(final List<TestLineSegment> segments) {
         this.segments = Collections.unmodifiableList(new ArrayList<>(segments));

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/AbstractBounds.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/AbstractBounds.java
@@ -118,11 +118,11 @@ public abstract class AbstractBounds<
      */
     public abstract boolean intersects(B other);
 
-    /** Return the intersection of this bounding box and the argument, or null if no intersection exists.
+    /** Return the intersection of this bounding box and the argument, or {@code null} if no intersection exists.
      * Floating point comparisons are strict; values are considered equal only if they match exactly. Note
      * this method may return bounding boxes with zero size in one or more coordinate axes.
      * @param other bounding box to intersect with
-     * @return the intersection of this instance and the argument, or null if no such intersection
+     * @return the intersection of this instance and the argument, or {@code null} if no such intersection
      *      exists
      * @see #intersects(AbstractBounds)
      */
@@ -240,7 +240,7 @@ public abstract class AbstractBounds<
         }
 
         /** Get an object representing the <em>first</em> intersection of the line convex subset
-         * with the boundaries of the bounding box. Null is returned if no such intersection exists.
+         * with the boundaries of the bounding box. {@code null} is returned if no such intersection exists.
          * @return object representing the first intersection of the line convex subset with the
          *      boundaries of the bounding box, or {@code null} if no such intersection exists
          */

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/AbstractNSphere.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/AbstractNSphere.java
@@ -277,7 +277,7 @@ public abstract class AbstractNSphere<V extends EuclideanVector<V>> implements R
      * @param abscissaFn function used to compute the abscissa value of a point on a line
      * @param distanceFn function used to compute the smallest distance between a point
      *      and a line
-     * @return the first intersection between the given line and this instance or null if
+     * @return the first intersection between the given line and this instance or {@code null} if
      *      no such intersection exists
      */
     protected <L extends Embedding<V, Vector1D>> V firstIntersection(final L line,

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/PointMap1DImpl.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/PointMap1DImpl.java
@@ -178,7 +178,7 @@ final class PointMap1DImpl<V>
         /** Get a {@link DistancedValue} instance containing the next entry from the given
          * iterator.
          * @param it iterator to get the next value from
-         * @return distanced value containing the next entry from the iterator or null if the iterator
+         * @return distanced value containing the next entry from the iterator or {@code null} if the iterator
          *      does not contain any more elements
          */
         private DistancedValue<Entry<Vector1D, V>> getNextEntry(final Iterator<Entry<Vector1D, V>> it) {

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/PointMap2DImpl.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/PointMap2DImpl.java
@@ -90,7 +90,7 @@ final class PointMap2DImpl<V>
      */
     private static final class MapNode2D<V> extends BucketNode<Vector2D, V> {
 
-        /** Point to split child spaces; will be null for leaf nodes. */
+        /** Point to split child spaces; will be {@code null} for leaf nodes. */
         private Vector2D split;
 
         /** Construct a new instance.

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/PointMap3DImpl.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/PointMap3DImpl.java
@@ -110,7 +110,7 @@ final class PointMap3DImpl<V>
      */
     private static final class MapNode3D<V> extends BucketNode<Vector3D, V> {
 
-        /** Point to split child spaces; will be null for leaf nodes. */
+        /** Point to split child spaces; will be {@code null} for leaf nodes. */
         private Vector3D split;
 
         /** Construct a new instance.

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/internal/AbstractPathConnector.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/internal/AbstractPathConnector.java
@@ -134,9 +134,9 @@ public abstract class AbstractPathConnector<E extends AbstractPathConnector.Conn
     }
 
     /** Connect the end point of the given element to the start point of another element. Returns
-     * the newly connected element or null if no forward connection was made.
+     * the newly connected element or {@code null} if no forward connection was made.
      * @param element element to connect
-     * @return the next element in the path or null if no connection was made
+     * @return the next element in the path or {@code null} if no connection was made
      */
     private E makeForwardConnection(final E element) {
         findPossibleConnections(element);
@@ -354,7 +354,7 @@ public abstract class AbstractPathConnector<E extends AbstractPathConnector.Conn
          * (or this element in the case of a loop). Each path can only be
          * exported once. Later calls to this method on this instance or any of its
          * connected elements will return null.
-         * @return the root of the path or null if the path that this element
+         * @return the root of the path or {@code null} if the path that this element
          *      belongs to has already been exported
          */
         public E exportPath() {

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/oned/Interval.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/oned/Interval.java
@@ -37,13 +37,13 @@ public final class Interval implements HyperplaneBoundedRegion<Vector1D> {
     private static final Interval FULL = new Interval(null, null);
 
     /** {@link OrientedPoint} instance representing the min boundary of the interval,
-     * or null if no min boundary exists. If present, this instance will be negative-facing.
+     * or {@code null} if no min boundary exists. If present, this instance will be negative-facing.
      * Infinite values are allowed but not NaN.
      */
     private final OrientedPoint minBoundary;
 
     /** {@link OrientedPoint} instance representing the max boundary of the interval,
-     * or null if no max boundary exists. If present, this instance will be negative-facing.
+     * or {@code null} if no max boundary exists. If present, this instance will be negative-facing.
      * Infinite values are allowed but not NaN.
      */
     private final OrientedPoint maxBoundary;
@@ -79,7 +79,7 @@ public final class Interval implements HyperplaneBoundedRegion<Vector1D> {
 
     /**
      * Get the {@link OrientedPoint} forming the minimum bounding hyperplane
-     * of the interval, or null if none exists. If present, This hyperplane
+     * of the interval, or {@code null} if none exists. If present, This hyperplane
      * is oriented to point in the negative direction.
      * @return the hyperplane forming the minimum boundary of the interval or
      *      null if no minimum boundary exists
@@ -90,7 +90,7 @@ public final class Interval implements HyperplaneBoundedRegion<Vector1D> {
 
     /**
      * Get the {@link OrientedPoint} forming the maximum bounding hyperplane
-     * of the interval, or null if none exists. If present, this hyperplane
+     * of the interval, or {@code null} if none exists. If present, this hyperplane
      * is oriented to point in the positive direction.
      * @return the hyperplane forming the maximum boundary of the interval or
      *      null if no maximum boundary exists

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/oned/Vector1D.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/oned/Vector1D.java
@@ -276,7 +276,7 @@ public class Vector1D extends EuclideanVector<Vector1D> {
      *
      * @param other Object to test for equality to this
      * @return true if two vector objects are equal, false if
-     *         object is null, not an instance of Vector1D, or
+     *         object is {@code null}, not an instance of Vector1D, or
      *         not equal to this Vector1D instance
      *
      */
@@ -399,7 +399,7 @@ public class Vector1D extends EuclideanVector<Vector1D> {
          * is returned.
          * @param x x coordinate
          * @param throwOnFailure if true, an exception will be thrown if a normalized vector cannot be created
-         * @return normalized vector or null if one cannot be created and {@code throwOnFailure}
+         * @return normalized vector or {@code null} if one cannot be created and {@code throwOnFailure}
          *      is false
          * @throws IllegalArgumentException if the computed norm is zero, NaN, or infinite
          */

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/AbstractEmbeddedRegionPlaneSubset.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/AbstractEmbeddedRegionPlaneSubset.java
@@ -117,7 +117,7 @@ abstract class AbstractEmbeddedRegionPlaneSubset extends AbstractPlaneSubset imp
 
     /** Compute 3D bounds from a subspace boundary source.
      * @param src subspace boundary source
-     * @return 3D bounds from the given embedded subspace boundary source or null
+     * @return 3D bounds from the given embedded subspace boundary source or {@code null}
      *      if no valid bounds could be determined
      */
     protected Bounds3D getBoundsFromSubspace(final BoundarySource2D src) {

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/BoundarySource3D.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/BoundarySource3D.java
@@ -92,9 +92,9 @@ public interface BoundarySource3D extends BoundarySource<PlaneConvexSubset>, Lin
     }
 
     /** Get a {@link Bounds3D} object defining the axis-aligned box containing all vertices
-     * in the boundaries for this instance. Null is returned if any boundary is infinite
+     * in the boundaries for this instance. {@code null} is returned if any boundary is infinite
      * or no vertices are found.
-     * @return the bounding box for this instance or null if no valid bounds could be determined
+     * @return the bounding box for this instance or {@code null} if no valid bounds could be determined
      */
     default Bounds3D getBounds() {
         return new BoundarySourceBoundsBuilder3D().getBounds(this);

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/BoundarySourceBoundsBuilder3D.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/BoundarySourceBoundsBuilder3D.java
@@ -22,15 +22,15 @@ import java.util.stream.Stream;
 
 /** Class used to construct {@link Bounds3D} instances representing the min and
  * max points present in a {@link BoundarySource3D}. The implementation examines
- * the vertices of each boundary in turn. Null is returned if any boundaries are
+ * the vertices of each boundary in turn. {@code null} is returned if any boundaries are
  * infinite or no vertices are present.
  */
 final class BoundarySourceBoundsBuilder3D {
 
     /** Get a {@link Bounds3D} instance containing all vertices in the given boundary source.
-     * Null is returned if any encountered boundaries were not finite or no vertices were found.
+     * {@code null} is returned if any encountered boundaries were not finite or no vertices were found.
      * @param src the boundary source to compute the bounds of
-     * @return the bounds of the argument or null if no valid bounds could be determined
+     * @return the bounds of the argument or {@code null} if no valid bounds could be determined
      */
     public Bounds3D getBounds(final BoundarySource3D src) {
         final Bounds3D.Builder builder = Bounds3D.builder();

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/BoundarySourceLinecaster3D.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/BoundarySourceLinecaster3D.java
@@ -79,7 +79,7 @@ final class BoundarySourceLinecaster3D implements Linecastable3D {
      * returned if no intersection is discovered.
      * @param planeSubset plane subset from the boundary source
      * @param lineSubset line subset to intersect with
-     * @return the linecast intersection between the two arguments or null if there is no such
+     * @return the linecast intersection between the two arguments or {@code null} if there is no such
      *      intersection
      */
     private LinecastPoint3D computeIntersection(final PlaneConvexSubset planeSubset,

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/Plane.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/Plane.java
@@ -238,10 +238,10 @@ public class Plane extends AbstractHyperplane<Vector3D> {
      * is the normal of the current instance and <code>n<sub>2</sub></code> is the normal
      * of the argument.
      *
-     * <p>Null is returned if the planes are parallel.</p>
+     * <p>{@code null} is returned if the planes are parallel.</p>
      *
      * @param other other plane
-     * @return line at the intersection of the instance and the other plane, or null
+     * @return line at the intersection of the instance and the other plane, or {@code null}
      *      if no such line exists
      */
     public Line3D intersection(final Plane other) {
@@ -403,7 +403,7 @@ public class Plane extends AbstractHyperplane<Vector3D> {
      * @param plane1 first plane1
      * @param plane2 second plane2
      * @param plane3 third plane2
-     * @return intersection point of the three planes or null if no unique intersection point exists
+     * @return intersection point of the three planes or {@code null} if no unique intersection point exists
      */
     public static Vector3D intersection(final Plane plane1, final Plane plane2, final Plane plane3) {
 

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/PlaneSubset.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/PlaneSubset.java
@@ -55,9 +55,9 @@ public interface PlaneSubset extends HyperplaneSubset<Vector3D> {
     List<Triangle3D> toTriangles();
 
     /** Get a {@link Bounds3D} object defining an axis-aligned bounding box containing all
-     * vertices for this subset. Null is returned if the subset is infinite or does not
+     * vertices for this subset. {@code null} is returned if the subset is infinite or does not
      * contain any vertices.
-     * @return the bounding box for this instance or null if no valid bounds could be determined
+     * @return the bounding box for this instance or {@code null} if no valid bounds could be determined
      */
     Bounds3D getBounds();
 
@@ -71,7 +71,7 @@ public interface PlaneSubset extends HyperplaneSubset<Vector3D> {
      * parallel or coincident) or the line does not intersect the plane subset.
      * @param line line to intersect with this plane subset
      * @return the unique intersection point between the line and this plane subset
-     *      or null if no such point exists.
+     *      or {@code null} if no such point exists.
      * @see Plane#intersection(Line3D)
      */
     Vector3D intersection(Line3D line);

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/Planes.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/Planes.java
@@ -404,7 +404,7 @@ public final class Planes {
      * @param planeSubset plane subset to intersect with
      * @param line line to intersect with this plane subset
      * @return the unique intersection point between the line and this plane subset
-     *      or null if no such point exists.
+     *      or {@code null} if no such point exists.
      */
     static Vector3D intersection(final PlaneSubset planeSubset, final Line3D line) {
         final Vector3D pt = planeSubset.getPlane().intersection(line);

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/RegionBSPTree3D.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/RegionBSPTree3D.java
@@ -652,11 +652,11 @@ public final class RegionBSPTree3D extends AbstractRegionBSPTree<Vector3D, Regio
             return Result.CONTINUE;
         }
 
-        /** Compute the linecast point for the given intersection point and tree node, returning null
+        /** Compute the linecast point for the given intersection point and tree node, returning {@code null}
          * if the point does not actually lie on the region boundary.
          * @param pt intersection point
          * @param node node containing the cut that the linecast line intersected with
-         * @return a new linecast point instance or null if the intersection point does not lie
+         * @return a new linecast point instance or {@code null} if the intersection point does not lie
          *      on the region boundary
          */
         private LinecastPoint3D computeLinecastPoint(final Vector3D pt, final RegionNode3D node) {

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/SphericalCoordinates.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/SphericalCoordinates.java
@@ -178,7 +178,7 @@ public final class SphericalCoordinates implements Spatial {
      *
      * @param other Object to test for equality to this
      * @return true if two SphericalCoordinates objects are equal, false if
-     *         object is null, not an instance of SphericalCoordinates, or
+     *         object is {@code null}, not an instance of SphericalCoordinates, or
      *         not equal to this SphericalCoordinates instance
      *
      */

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/Vector3D.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/Vector3D.java
@@ -430,7 +430,7 @@ public class Vector3D extends MultiDimensionalEuclideanVector<Vector3D> {
      *
      * @param other Object to test for equality to this
      * @return true if two Vector3D objects are equal, false if
-     *         object is null, not an instance of Vector3D, or
+     *         object is {@code null}, not an instance of Vector3D, or
      *         not equal to this Vector3D instance
      *
      */
@@ -771,7 +771,7 @@ public class Vector3D extends MultiDimensionalEuclideanVector<Vector3D> {
          * @param y y coordinate
          * @param z z coordinate
          * @param throwOnFailure if true, an exception will be thrown if a normalized vector cannot be created
-         * @return normalized vector or null if one cannot be created and {@code throwOnFailure}
+         * @return normalized vector or {@code null} if one cannot be created and {@code throwOnFailure}
          *      is false
          * @throws IllegalArgumentException if the computed norm is zero, NaN, or infinite
          */

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/line/Line3D.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/line/Line3D.java
@@ -261,7 +261,7 @@ public final class Line3D implements Embedding<Vector3D, Vector1D> {
     /** Get the intersection point of the instance and another line.
      * @param line other line
      * @return intersection point of the instance and the other line
-     * or null if there are no intersection points
+     * or {@code null} if there are no intersection points
      */
     public Vector3D intersection(final Line3D line) {
         final Vector3D closestPt = closest(line);

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/line/LineConvexSubset3D.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/line/LineConvexSubset3D.java
@@ -22,7 +22,7 @@ import org.apache.commons.geometry.euclidean.oned.Interval;
 import org.apache.commons.geometry.euclidean.threed.Vector3D;
 
 /** Class representing a convex subset of a line in 3D Euclidean space. Instances
- * need not be finite, in which case the start or end point (or both) will be null.
+ * need not be finite, in which case the start or end point (or both) will be {@code null}.
  * @see Lines3D
  */
 public abstract class LineConvexSubset3D extends LineSubset3D {
@@ -35,7 +35,7 @@ public abstract class LineConvexSubset3D extends LineSubset3D {
     }
 
     /** Get the start point for the line subset.
-     * @return the start point for the line subset, or null if no start point exists
+     * @return the start point for the line subset, or {@code null} if no start point exists
      */
     public abstract Vector3D getStartPoint();
 
@@ -47,7 +47,7 @@ public abstract class LineConvexSubset3D extends LineSubset3D {
     public abstract double getSubspaceStart();
 
     /** Get the end point for the line subset.
-     * @return the end point for the line subset, or null if no end point exists.
+     * @return the end point for the line subset, or {@code null} if no end point exists.
      */
     public abstract Vector3D getEndPoint();
 

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/line/LineSubset3D.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/line/LineSubset3D.java
@@ -57,16 +57,16 @@ public abstract class LineSubset3D implements RegionEmbedding<Vector3D, Vector1D
         return line.toSubspace(pt);
     }
 
-    /** Get the centroid, or geometric center, of the line subset or null if
+    /** Get the centroid, or geometric center, of the line subset or {@code null} if
      * the subset is empty or infinite.
-     * @return the centroid of the line subset, or null if the subset is empty or
+     * @return the centroid of the line subset, or {@code null} if the subset is empty or
      *      infinite
      */
     public abstract Vector3D getCentroid();
 
-    /** Get the 3D bounding box of the line subset or null if the subset is
+    /** Get the 3D bounding box of the line subset or {@code null} if the subset is
      * empty or infinite.
-     * @return the 3D bounding box the line subset or null if the subset is
+     * @return the 3D bounding box the line subset or {@code null} if the subset is
      *      empty or infinite
      */
     public abstract Bounds3D getBounds();

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/line/Linecastable3D.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/line/Linecastable3D.java
@@ -53,7 +53,7 @@ public interface Linecastable3D {
     /** Intersect the given line against the boundaries in this instance, returning the first
      * intersection found when traveling in the direction of the line from infinity.
      * @param line the line to intersect
-     * @return the first intersection found or null if no intersection
+     * @return the first intersection found or {@code null} if no intersection
      *      is found
      */
     default LinecastPoint3D linecastFirst(final Line3D line) {
@@ -64,7 +64,7 @@ public interface Linecastable3D {
      * the first intersection found when traveling in the direction of the line subset from its
      * start point.
      * @param subset line subset to intersect
-     * @return the first intersection found or null if no intersection
+     * @return the first intersection found or {@code null} if no intersection
      *      is found
      */
     LinecastPoint3D linecastFirst(LineConvexSubset3D subset);

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/shape/Sphere.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/threed/shape/Sphere.java
@@ -196,7 +196,7 @@ public final class Sphere extends AbstractNSphere<Vector3D> implements Linecasta
         return intersections(line, Line3D::abscissa, Line3D::distance);
     }
 
-    /** Get the first intersection point between the given line and this sphere, or null
+    /** Get the first intersection point between the given line and this sphere, or {@code null}
      * if no such point exists. The "first" intersection point is the first such point
      * encountered when traveling in the direction of the line from infinity.
      * @param line line to intersect with the sphere

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/BoundarySource2D.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/BoundarySource2D.java
@@ -65,9 +65,9 @@ public interface BoundarySource2D extends BoundarySource<LineConvexSubset>, Line
     }
 
     /** Get a {@link Bounds2D} object defining the axis-aligned box containing all vertices
-     * in the boundaries for this instance. Null is returned if any boundaries are infinite
+     * in the boundaries for this instance. {@code null} is returned if any boundaries are infinite
      * or no vertices were found.
-     * @return the bounding box for this instance or null if no valid bounds could be determined
+     * @return the bounding box for this instance or {@code null} if no valid bounds could be determined
      */
     default Bounds2D getBounds() {
         return new BoundarySourceBoundsBuilder2D().getBounds(this);

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/BoundarySourceBoundsBuilder2D.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/BoundarySourceBoundsBuilder2D.java
@@ -21,15 +21,15 @@ import java.util.stream.Stream;
 
 /** Class used to construct {@link Bounds2D} instances representing the min and
  * max points present in a {@link BoundarySource2D}. The implementation examines
- * the vertices of each boundary in turn. Null is returned if any boundaries are
+ * the vertices of each boundary in turn. {@code null} is returned if any boundaries are
  * infinite or no vertices are present.
  */
 final class BoundarySourceBoundsBuilder2D {
 
     /** Get a {@link Bounds2D} instance containing all vertices in the given boundary source.
-     * Null is returned if any encountered boundaries were not finite or no vertices were found.
+     * {@code null} is returned if any encountered boundaries were not finite or no vertices were found.
      * @param src boundary source to compute the bounds of
-     * @return the bounds of the argument or null if no valid bounds could be determined
+     * @return the bounds of the argument or {@code null} if no valid bounds could be determined
      */
     public Bounds2D getBounds(final BoundarySource2D src) {
 

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/BoundarySourceLinecaster2D.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/BoundarySourceLinecaster2D.java
@@ -75,7 +75,7 @@ final class BoundarySourceLinecaster2D implements Linecastable2D {
      * returned if no intersection is discovered.
      * @param boundary boundary from the boundary source
      * @param subset line subset to intersect with
-     * @return the linecast intersection between the two arguments or null if there is no such
+     * @return the linecast intersection between the two arguments or {@code null} if there is no such
      *      intersection
      */
     private LinecastPoint2D computeIntersection(final LineConvexSubset boundary, final LineConvexSubset subset) {

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/Line.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/Line.java
@@ -306,7 +306,7 @@ public final class Line extends AbstractHyperplane<Vector2D>
     /** Get the intersection point of the instance and another line.
      * @param other other line
      * @return intersection point of the instance and the other line
-     *      or null if there is no unique intersection point (ie, the lines
+     *      or {@code null} if there is no unique intersection point (ie, the lines
      *      are parallel or coincident)
      */
     public Vector2D intersection(final Line other) {

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/LineConvexSubset.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/LineConvexSubset.java
@@ -27,7 +27,7 @@ import org.apache.commons.geometry.core.partitioning.Split;
 import org.apache.commons.geometry.euclidean.oned.Interval;
 
 /** Class representing a convex subset of a line in 2D Euclidean space. Instances
- * need not be finite, in which case the start or end point (or both) will be null.
+ * need not be finite, in which case the start or end point (or both) will be {@code null}.
  * Line segments and rays are examples of convex line subsets.
  * @see Lines
  */
@@ -56,7 +56,7 @@ public abstract class LineConvexSubset extends LineSubset implements HyperplaneC
     }
 
     /** Get the start point for the subset.
-     * @return the start point for the subset, or null if no start point exists
+     * @return the start point for the subset, or {@code null} if no start point exists
      */
     public abstract Vector2D getStartPoint();
 
@@ -68,7 +68,7 @@ public abstract class LineConvexSubset extends LineSubset implements HyperplaneC
     public abstract double getSubspaceStart();
 
     /** Get the end point for the subset.
-     * @return the end point for the subset, or null if no end point exists.
+     * @return the end point for the subset, or {@code null} if no end point exists.
      */
     public abstract Vector2D getEndPoint();
 

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/LineSubset.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/LineSubset.java
@@ -62,9 +62,9 @@ public abstract class LineSubset implements HyperplaneSubset<Vector2D>, RegionEm
     }
 
     /** Get a {@link Bounds2D} object defining an axis-aligned bounding box containing all
-     * vertices for this subset. Null is returned if the subset is infinite or does not
+     * vertices for this subset. {@code null} is returned if the subset is infinite or does not
      * contain any vertices.
-     * @return the bounding box for this instance or null if no valid bounds could be determined
+     * @return the bounding box for this instance or {@code null} if no valid bounds could be determined
      */
     public abstract Bounds2D getBounds();
 
@@ -97,7 +97,7 @@ public abstract class LineSubset implements HyperplaneSubset<Vector2D>, RegionEm
      * parallel or coincident) or the line does not intersect this instance.
      * @param inputLine line to intersect with this line subset
      * @return the unique intersection point between the line and this line subset
-     *      or null if no such point exists.
+     *      or {@code null} if no such point exists.
      * @see Line#intersection(Line)
      */
     public Vector2D intersection(final Line inputLine) {

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/Linecastable2D.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/Linecastable2D.java
@@ -54,7 +54,7 @@ public interface Linecastable2D {
      * the first intersection found when traveling in the direction of the line from
      * infinity.
      * @param line the line to intersect
-     * @return the first intersection found or null if no intersection
+     * @return the first intersection found or {@code null} if no intersection
      *      is found
      */
     default LinecastPoint2D linecastFirst(final Line line) {
@@ -65,7 +65,7 @@ public interface Linecastable2D {
      * the first intersection found when traveling in the direction of the line subset
      * from its start location.
      * @param subset line subset to intersect
-     * @return the first intersection found or null if no intersection
+     * @return the first intersection found or {@code null} if no intersection
      *      is found
      */
     LinecastPoint2D linecastFirst(LineConvexSubset subset);

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/PolarCoordinates.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/PolarCoordinates.java
@@ -145,7 +145,7 @@ public final class PolarCoordinates implements Spatial {
      *
      * @param other Object to test for equality to this
      * @return true if two PolarCoordinates objects are equal, false if
-     *         object is null, not an instance of PolarCoordinates, or
+     *         object is {@code null}, not an instance of PolarCoordinates, or
      *         not equal to this PolarCoordinates instance
      *
      */

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/RegionBSPTree2D.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/RegionBSPTree2D.java
@@ -632,11 +632,11 @@ public final class RegionBSPTree2D extends AbstractRegionBSPTree<Vector2D, Regio
             return Result.CONTINUE;
         }
 
-        /** Compute the linecast point for the given intersection point and tree node, returning null
+        /** Compute the linecast point for the given intersection point and tree node, returning {@code null}
          * if the point does not actually lie on the region boundary.
          * @param pt intersection point
          * @param node node containing the cut that the linecast line intersected with
-         * @return a new linecast point instance or null if the intersection point does not lie
+         * @return a new linecast point instance or {@code null} if the intersection point does not lie
          *      on the region boundary
          */
         private LinecastPoint2D computeLinecastPoint(final Vector2D pt, final RegionNode2D node) {

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/Vector2D.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/Vector2D.java
@@ -369,7 +369,7 @@ public class Vector2D extends MultiDimensionalEuclideanVector<Vector2D> {
      *
      * @param other Object to test for equality to this
      * @return true if two Vector2D objects are equal, false if
-     *         object is null, not an instance of Vector2D, or
+     *         object is {@code null}, not an instance of Vector2D, or
      *         not equal to this Vector2D instance
      *
      */
@@ -701,7 +701,7 @@ public class Vector2D extends MultiDimensionalEuclideanVector<Vector2D> {
          * @param x x coordinate
          * @param y y coordinate
          * @param throwOnFailure if true, an exception will be thrown if a normalized vector cannot be created
-         * @return normalized vector or null if one cannot be created and {@code throwOnFailure}
+         * @return normalized vector or {@code null} if one cannot be created and {@code throwOnFailure}
          *      is false
          * @throws IllegalArgumentException if the computed norm is zero, NaN, or infinite
          */

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/path/LinePath.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/path/LinePath.java
@@ -70,10 +70,10 @@ public class LinePath implements BoundarySource2D, Sized {
         return elements;
     }
 
-    /** Get the line subset at the start of the path or null if the path is empty. If the
+    /** Get the line subset at the start of the path or {@code null} if the path is empty. If the
      * path consists of a single line subset, then the returned instance with be the same
      * as that returned by {@link #getEnd()}.
-     * @return the line subset at the start of the path or null if the path is empty
+     * @return the line subset at the start of the path or {@code null} if the path is empty
      * @see #getEnd()
      */
     public LineConvexSubset getStart() {
@@ -83,10 +83,10 @@ public class LinePath implements BoundarySource2D, Sized {
         return null;
     }
 
-    /** Get the line subset at the end of the path or null if the path is empty. If the
+    /** Get the line subset at the end of the path or {@code null} if the path is empty. If the
      * path consists of a single line subset, then the returned instance with be the same
      * as that returned by {@link #getStart()}.
-     * @return the line subset at the end of the path or null if the path is empty
+     * @return the line subset at the end of the path or {@code null} if the path is empty
      * @see #getStart()
      */
     public LineConvexSubset getEnd() {
@@ -339,9 +339,9 @@ public class LinePath implements BoundarySource2D, Sized {
         return sb.toString();
     }
 
-    /** Get the start vertex for the path or null if the path is empty
+    /** Get the start vertex for the path or {@code null} if the path is empty
      * or has an infinite start line subset.
-     * @return the start vertex for the path or null if the path does
+     * @return the start vertex for the path or {@code null} if the path does
      *      not start with a vertex
      */
     private Vector2D getStartVertex() {
@@ -349,9 +349,9 @@ public class LinePath implements BoundarySource2D, Sized {
         return (seg != null) ? seg.getStartPoint() : null;
     }
 
-    /** Get the end vertex for the path or null if the path is empty
+    /** Get the end vertex for the path or {@code null} if the path is empty
      * or has an infinite end line subset.
-     * @return the end vertex for the path or null if the path does
+     * @return the end vertex for the path or {@code null} if the path does
      *      not end with a vertex
      */
     private Vector2D getEndVertex() {
@@ -447,7 +447,7 @@ public class LinePath implements BoundarySource2D, Sized {
      * context. The precision context is used when building line segments from
      * vertices and may be omitted if raw vertices are not used.
      * @param precision precision context to use when building line segments from
-     *      raw vertices; may be null if raw vertices are not used.
+     *      raw vertices; may be {@code null} if raw vertices are not used.
      * @return a new {@link Builder} instance
      */
     public static Builder builder(final Precision.DoubleEquivalence precision) {
@@ -500,7 +500,7 @@ public class LinePath implements BoundarySource2D, Sized {
             return this;
         }
 
-        /** Get the line subset at the start of the path or null if it does not exist.
+        /** Get the line subset at the start of the path or {@code null} if it does not exist.
          * @return the line subset at the start of the path
          */
         public LineConvexSubset getStart() {
@@ -511,7 +511,7 @@ public class LinePath implements BoundarySource2D, Sized {
             return start;
         }
 
-        /** Get the line subset at the end of the path or null if it does not exist.
+        /** Get the line subset at the end of the path or {@code null} if it does not exist.
          * @return the line subset at the end of the path
          */
         public LineConvexSubset getEnd() {
@@ -750,7 +750,7 @@ public class LinePath implements BoundarySource2D, Sized {
 
         /** Validate that the given line subsets  are connected, meaning that the end vertex of {@code previous}
          * is equivalent to the start vertex of {@code next}. The line subsets are considered valid if either
-         * line subset is null.
+         * line subset is {@code null}.
          * @param previous previous line subset
          * @param next next line subset
          * @throws IllegalStateException if previous and next are not null and the end vertex of previous
@@ -823,10 +823,10 @@ public class LinePath implements BoundarySource2D, Sized {
             prepended.add(subset);
         }
 
-        /** Get the first element in the list or null if the list is null
+        /** Get the first element in the list or {@code null} if the list is {@code null}
          * or empty.
          * @param list the list to return the first item from
-         * @return the first item from the given list or null if it does not exist
+         * @return the first item from the given list or {@code null} if it does not exist
          */
         private LineConvexSubset getFirst(final List<? extends LineConvexSubset> list) {
             if (list != null && !list.isEmpty()) {
@@ -835,10 +835,10 @@ public class LinePath implements BoundarySource2D, Sized {
             return null;
         }
 
-        /** Get the last element in the list or null if the list is null
+        /** Get the last element in the list or {@code null} if the list is {@code null}
          * or empty.
          * @param list the list to return the last item from
-         * @return the last item from the given list or null if it does not exist
+         * @return the last item from the given list or {@code null} if it does not exist
          */
         private LineConvexSubset getLast(final List<? extends LineConvexSubset> list) {
             if (list != null && !list.isEmpty()) {

--- a/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/shape/Circle.java
+++ b/commons-geometry-euclidean/src/main/java/org/apache/commons/geometry/euclidean/twod/shape/Circle.java
@@ -108,7 +108,7 @@ public final class Circle extends AbstractNSphere<Vector2D> implements Linecasta
         return intersections(line, Line::abscissa, Line::distance);
     }
 
-    /** Get the first intersection point between the given line and this circle, or null
+    /** Get the first intersection point between the given line and this circle, or {@code null}
      * if no such point exists. The "first" intersection point is the first such point
      * encountered when traveling in the direction of the line from infinity.
      * @param line line to intersect with the circle

--- a/commons-geometry-examples/examples-jmh/src/main/java/org/apache/commons/geometry/examples/jmh/euclidean/pointmap/BucketKDTree.java
+++ b/commons-geometry-examples/examples-jmh/src/main/java/org/apache/commons/geometry/examples/jmh/euclidean/pointmap/BucketKDTree.java
@@ -247,10 +247,10 @@ public class BucketKDTree<V> extends AbstractMap<Vector3D, V> {
             this.parent = parent;
         }
 
-        /** Return the map entry equivalent to the given key or null if not
+        /** Return the map entry equivalent to the given key or {@code null} if not
          * found.
          * @param key key to search for
-         * @return entry equivalent to {@code key} or null if not found
+         * @return entry equivalent to {@code key} or {@code null} if not found
          */
         public abstract Vector3DEntry<V> find(Vector3D key);
 
@@ -274,10 +274,10 @@ public class BucketKDTree<V> extends AbstractMap<Vector3D, V> {
          */
         public abstract void insertExisting(Vector3DEntry<V> entry);
 
-        /** Remove the map entry equivalent to the given key or null if one
+        /** Remove the map entry equivalent to the given key or {@code null} if one
          * was not found.
          * @param key map key
-         * @return the removed entry or null if not found
+         * @return the removed entry or {@code null} if not found
          */
         public abstract Vector3DEntry<V> remove(Vector3D key);
 
@@ -336,7 +336,7 @@ public class BucketKDTree<V> extends AbstractMap<Vector3D, V> {
         }
 
         /** Replace this node with the given node.
-         * @param node replacement node; may be null
+         * @param node replacement node; may be {@code null}
          */
         protected void replaceSelf(final Node<V> node) {
             if (parent == null) {
@@ -375,10 +375,10 @@ public class BucketKDTree<V> extends AbstractMap<Vector3D, V> {
         /** Map entry. */
         private Vector3DEntry<V> entry;
 
-        /** Left child node; may be null. */
+        /** Left child node; may be {@code null}. */
         private Node<V> left;
 
-        /** Right child node; may be null. */
+        /** Right child node; may be {@code null}. */
         private Node<V> right;
 
         /** Cut dimension; not null. */
@@ -961,7 +961,7 @@ public class BucketKDTree<V> extends AbstractMap<Vector3D, V> {
     }
 
     /** Return the node containing the minimum value along the given cut dimension. If one
-     * argument is null, the other argument is returned.
+     * argument is {@code null}, the other argument is returned.
      * @param <V> Value type
      * @param a first node
      * @param b second node

--- a/commons-geometry-examples/examples-jmh/src/main/java/org/apache/commons/geometry/examples/jmh/euclidean/pointmap/KDTree.java
+++ b/commons-geometry-examples/examples-jmh/src/main/java/org/apache/commons/geometry/examples/jmh/euclidean/pointmap/KDTree.java
@@ -66,7 +66,7 @@ public class KDTree<V> extends AbstractMap<Vector3D, V> {
     /** Precision context. */
     private final Precision.DoubleEquivalence precision;
 
-    /** Root node; may be null. */
+    /** Root node; may be {@code null}. */
     private KDTreeNode<V> root;
 
     /** Tree node count. */
@@ -295,10 +295,10 @@ public class KDTree<V> extends AbstractMap<Vector3D, V> {
         }
     }
 
-    /** Find the node with the given {@code key} or null if not found.
+    /** Find the node with the given {@code key} or {@code null} if not found.
      * @param node subtree root
      * @param key map key
-     * @return the node matching the given {@code key} or null if not found
+     * @return the node matching the given {@code key} or {@code null} if not found
      */
     private KDTreeNode<V> findNodeRecursive(final KDTreeNode<V> node, final Vector3D key) {
         if (node != null) {
@@ -376,8 +376,8 @@ public class KDTree<V> extends AbstractMap<Vector3D, V> {
     /** Find the node with the minimum value along the given cut dimension.
      * @param node subtree root
      * @param cutDimension cut dimension to search along
-     * @return node with the minimum value along the cut dimension or null if {@code node}
-     *      is null
+     * @return node with the minimum value along the cut dimension or {@code null} if {@code node}
+     *      is {@code null}
      */
     private KDTreeNode<V> findMin(final KDTreeNode<V> node, final CutDimension cutDimension) {
         if (node != null) {
@@ -419,7 +419,7 @@ public class KDTree<V> extends AbstractMap<Vector3D, V> {
     }
 
     /** Return the node containing the minimum value along the given cut dimension. If one
-     * argument is null, the other argument is returned.
+     * argument is {@code null}, the other argument is returned.
      * @param a first node
      * @param b second node
      * @param cutDimension search dimension
@@ -452,7 +452,7 @@ public class KDTree<V> extends AbstractMap<Vector3D, V> {
      */
     static final class KDTreeNode<V> implements Map.Entry<Vector3D, V> {
 
-        /** Parent node; may be null. */
+        /** Parent node; may be {@code null}. */
         private KDTreeNode<V> parent;
 
         /** Map key value. */
@@ -461,17 +461,17 @@ public class KDTree<V> extends AbstractMap<Vector3D, V> {
         /** Map entry value. */
         private V value;
 
-        /** Left child; may be null. */
+        /** Left child; may be {@code null}. */
         private KDTreeNode<V> left;
 
-        /** Right child; may be null. */
+        /** Right child; may be {@code null}. */
         private KDTreeNode<V> right;
 
         /** Node cut dimension. */
         private CutDimension cutDimension;
 
         /** Construct a new instance.
-         * @param parent parent node; may be null
+         * @param parent parent node; may be {@code null}
          * @param key map key
          * @param cutDimension cut dimension
          */
@@ -517,7 +517,7 @@ public class KDTree<V> extends AbstractMap<Vector3D, V> {
         }
 
         /** Get the parent node.
-         * @return parent node; may be null
+         * @return parent node; may be {@code null}
          */
         public KDTreeNode<V> getParent() {
             return parent;
@@ -531,7 +531,7 @@ public class KDTree<V> extends AbstractMap<Vector3D, V> {
         }
 
         /** Get the left child node.
-         * @return left child node; may be null
+         * @return left child node; may be {@code null}
          */
         public KDTreeNode<V> getLeft() {
             return left;
@@ -545,7 +545,7 @@ public class KDTree<V> extends AbstractMap<Vector3D, V> {
         }
 
         /** Get the right child node.
-         * @return right child node; may be null
+         * @return right child node; may be {@code null}
          */
         public KDTreeNode<V> getRight() {
             return right;

--- a/commons-geometry-examples/examples-jmh/src/main/java/org/apache/commons/geometry/examples/jmh/euclidean/pointmap/VariableSplitOctree.java
+++ b/commons-geometry-examples/examples-jmh/src/main/java/org/apache/commons/geometry/examples/jmh/euclidean/pointmap/VariableSplitOctree.java
@@ -169,7 +169,7 @@ public class VariableSplitOctree<V> extends AbstractMap<Vector3D, V> {
         /** Points stored in the node; this will only be populated for leaf nodes. */
         private List<Vector3DEntry<V>> entries = new ArrayList<>(MAX_ENTRIES);
 
-        /** The split point of the node; will be null for leaf nodes. */
+        /** The split point of the node; will be {@code null} for leaf nodes. */
         private Vector3D splitPoint;
 
         VariableSplitOctreeNode(final VariableSplitOctree<V> map) {
@@ -220,9 +220,9 @@ public class VariableSplitOctree<V> extends AbstractMap<Vector3D, V> {
             }
         }
 
-        /** Get the entry matching the given key or null if not found.
+        /** Get the entry matching the given key or {@code null} if not found.
          * @param key key to search for
-         * @return the entry matching the given key or null if not found
+         * @return the entry matching the given key or {@code null} if not found
          */
         public Vector3DEntry<V> getEntry(final Vector3D key) {
             if (isLeaf()) {
@@ -254,7 +254,7 @@ public class VariableSplitOctree<V> extends AbstractMap<Vector3D, V> {
 
         /** Remove the given key, returning the previously mapped entry.
          * @param key key to remove
-         * @return the value previously mapped to the key or null if no
+         * @return the value previously mapped to the key or {@code null} if no
          *       value was mapped
          */
         public Vector3DEntry<V> removeEntry(final Vector3D key) {
@@ -291,10 +291,10 @@ public class VariableSplitOctree<V> extends AbstractMap<Vector3D, V> {
             return null;
         }
 
-        /** Get the given entry in the child at {@code idx} or null if not found.
+        /** Get the given entry in the child at {@code idx} or {@code null} if not found.
          * @param idx child index
          * @param key key to search for
-         * @return entry matching {@code key} in child or null if not found
+         * @return entry matching {@code key} in child or {@code null} if not found
          */
         private Vector3DEntry<V> getEntryInChild(final int idx, final Vector3D key) {
             final VariableSplitOctreeNode<V> child = children.get(idx);
@@ -307,7 +307,7 @@ public class VariableSplitOctree<V> extends AbstractMap<Vector3D, V> {
         /** Remove the given key from the child at {@code idx}.
          * @param idx index of the child
          * @param key key to remove
-         * @return entry removed from the child or null if not found
+         * @return entry removed from the child or {@code null} if not found
          */
         private Vector3DEntry<V> removeFromChild(final int idx, final Vector3D key) {
             final VariableSplitOctreeNode<V> child = children.get(idx);

--- a/commons-geometry-io-core/src/main/java/org/apache/commons/geometry/io/core/BoundaryIOManager.java
+++ b/commons-geometry-io-core/src/main/java/org/apache/commons/geometry/io/core/BoundaryIOManager.java
@@ -71,13 +71,13 @@ public class BoundaryIOManager<
     R extends BoundaryReadHandler<H, B>,
     W extends BoundaryWriteHandler<H, B>> {
 
-    /** Error message used when a handler is null. */
+    /** Error message used when a handler is {@code null}. */
     private static final String HANDLER_NULL_ERR = "Handler cannot be null";
 
-    /** Error message used when a format is null. */
+    /** Error message used when a format is {@code null}. */
     private static final String FORMAT_NULL_ERR = "Format cannot be null";
 
-    /** Error message used when a format name is null. */
+    /** Error message used when a format name is {@code null}. */
     private static final String FORMAT_NAME_NULL_ERR = "Format name cannot be null";
 
     /** Read handler registry. */
@@ -104,8 +104,8 @@ public class BoundaryIOManager<
     }
 
     /** Unregister a previously registered {@link BoundaryReadHandler read handler};
-     * does nothing if the argument is null or is not currently registered.
-     * @param handler handler to unregister; may be null
+     * does nothing if the argument is {@code null} or is not currently registered.
+     * @param handler handler to unregister; may be {@code null}
      */
     public void unregisterReadHandler(final R handler) {
         readRegistry.unregister(handler);
@@ -132,17 +132,17 @@ public class BoundaryIOManager<
     /** Get the {@link BoundaryReadHandler read handler} for the given format or
      * null if no such handler has been registered.
      * @param fmt format to obtain a handler for
-     * @return read handler for the given format or null if not found
+     * @return read handler for the given format or {@code null} if not found
      */
     public R getReadHandlerForFormat(final GeometryFormat fmt) {
         return readRegistry.getByFormat(fmt);
     }
 
     /** Get the {@link BoundaryReadHandler read handler} for the given file extension
-     * or null if no such handler has been registered. File extension comparisons are
+     * or {@code null} if no such handler has been registered. File extension comparisons are
      * not case-sensitive.
      * @param fileExt file extension to obtain a handler for
-     * @return read handler for the given file extension or null if not found
+     * @return read handler for the given file extension or {@code null} if not found
      * @see GeometryFormat#getFileExtensions()
      */
     public R getReadHandlerForFileExtension(final String fileExt) {
@@ -162,8 +162,8 @@ public class BoundaryIOManager<
     }
 
     /** Unregister a previously registered {@link BoundaryWriteHandler write handler};
-     * does nothing if the argument is null or is not currently registered.
-     * @param handler handler to unregister; may be null
+     * does nothing if the argument is {@code null} or is not currently registered.
+     * @param handler handler to unregister; may be {@code null}
      */
     public void unregisterWriteHandler(final W handler) {
         writeRegistry.unregister(handler);
@@ -190,17 +190,17 @@ public class BoundaryIOManager<
     /** Get the {@link BoundaryWriteHandler write handler} for the given format or
      * null if no such handler has been registered.
      * @param fmt format to obtain a handler for
-     * @return write handler for the given format or null if not found
+     * @return write handler for the given format or {@code null} if not found
      */
     public W getWriteHandlerForFormat(final GeometryFormat fmt) {
         return writeRegistry.getByFormat(fmt);
     }
 
     /** Get the {@link BoundaryWriteHandler write handler} for the given file extension
-     * or null if no such handler has been registered. File extension comparisons are
+     * or {@code null} if no such handler has been registered. File extension comparisons are
      * not case-sensitive.
      * @param fileExt file extension to obtain a handler for
-     * @return write handler for the given file extension or null if not found
+     * @return write handler for the given file extension or {@code null} if not found
      * @see GeometryFormat#getFileExtensions()
      */
     public W getWriteHandlerForFileExtension(final String fileExt) {
@@ -210,7 +210,7 @@ public class BoundaryIOManager<
     /** Return a {@link BoundarySource} containing all boundaries from the given input.
      * A runtime exception may be thrown if mathematically invalid boundaries are encountered.
      * @param in input to read boundaries from
-     * @param fmt format of the input; if null, the format is determined implicitly from the
+     * @param fmt format of the input; if {@code null}, the format is determined implicitly from the
      *      file extension of the input {@link GeometryInput#getFileName() file name}
      * @param precision precision context used for floating point comparisons
      * @return object containing all boundaries from the input
@@ -238,7 +238,7 @@ public class BoundaryIOManager<
      *      <li>{@link java.io.UncheckedIOException UncheckedIOException} if an I/O error occurs</li>
      *  </ul>
      * @param in input to read boundaries from
-     * @param fmt format of the input; if null, the format is determined implicitly from the
+     * @param fmt format of the input; if {@code null}, the format is determined implicitly from the
      *      file extension of the input {@link GeometryInput#getFileName() file name}
      * @param precision precision context used for floating point comparisons
      * @return stream providing access to all boundaries from the input
@@ -255,7 +255,7 @@ public class BoundaryIOManager<
     /** Write all boundaries from {@code src} to the given output.
      * @param src object containing boundaries to write
      * @param out output to write boundaries to
-     * @param fmt format of the output; if null, the format is determined implicitly from the
+     * @param fmt format of the output; if {@code null}, the format is determined implicitly from the
      *      file extension of the output {@link GeometryOutput#getFileName()}
      * @throws IllegalArgumentException if no {@link BoundaryWriteHandler write handler} can be found
      *      for the output format
@@ -267,14 +267,14 @@ public class BoundaryIOManager<
 
     /** Get the {@link BoundaryReadHandler read handler} matching the arguments, throwing an exception
      * on failure. If {@code fmt} is given, the handler registered for that format is returned and the
-     * {@code input} object is not examined. If {@code fmt} is null, the file extension of the input
+     * {@code input} object is not examined. If {@code fmt} is {@code null}, the file extension of the input
      * {@link GeometryInput#getFileName() file name} is used to implicitly determine the format and locate
      * the handler.
      * @param in input object
-     * @param fmt format; may be null
-     * @return the read handler for {@code fmt} or, if {@code fmt} is null, the read handler for the
+     * @param fmt format; may be {@code null}
+     * @return the read handler for {@code fmt} or, if {@code fmt} is {@code null}, the read handler for the
      *      file extension indicated by the input
-     * @throws NullPointerException if {@code in} is null
+     * @throws NullPointerException if {@code in} is {@code null}
      * @throws IllegalArgumentException if no matching handler can be found
      */
     protected R requireReadHandler(final GeometryInput in, final GeometryFormat fmt) {
@@ -284,14 +284,14 @@ public class BoundaryIOManager<
 
     /** Get the {@link BoundaryWriteHandler write handler} matching the arguments, throwing an exception
      * on failure. If {@code fmt} is given, the handler registered for that format is returned and the
-     * {@code input} object is not examined. If {@code fmt} is null, the file extension of the output
+     * {@code input} object is not examined. If {@code fmt} is {@code null}, the file extension of the output
      * {@link GeometryOutput#getFileName() file name} is used to implicitly determine the format and locate
      * the handler.
      * @param out output object
-     * @param fmt format; may be null
-     * @return the write handler for {@code fmt} or, if {@code fmt} is null, the write handler for the
+     * @param fmt format; may be {@code null}
+     * @return the write handler for {@code fmt} or, if {@code fmt} is {@code null}, the write handler for the
      *      file extension indicated by the output
-     * @throws NullPointerException if {@code out} is null
+     * @throws NullPointerException if {@code out} is {@code null}
      * @throws IllegalArgumentException if no matching handler can be found
      */
     protected W requireWriteHandler(final GeometryOutput out, final GeometryFormat fmt) {
@@ -317,7 +317,7 @@ public class BoundaryIOManager<
         /** Register a handler for the given {@link GeometryFormat format}.
          * @param fmt format for the handler
          * @param handler handler to register
-         * @throws NullPointerException if either argument is null
+         * @throws NullPointerException if either argument is {@code null}
          */
         public synchronized void register(final GeometryFormat fmt, final T handler) {
             Objects.requireNonNull(fmt, FORMAT_NULL_ERR);
@@ -346,9 +346,9 @@ public class BoundaryIOManager<
         }
 
         /** Unregister the current handler for the given format and return it.
-         * Null is returned if no handler was registered.
+         * {@code null} is returned if no handler was registered.
          * @param fmt format to unregister
-         * @return handler instance previously registered for the format or null
+         * @return handler instance previously registered for the format or {@code null}
          *      if not found
          */
         public synchronized T unregisterFormat(final GeometryFormat fmt) {
@@ -366,7 +366,7 @@ public class BoundaryIOManager<
             return Collections.unmodifiableList(new ArrayList<>(handlers));
         }
 
-        /** Get the first handler registered for the given format, or null if
+        /** Get the first handler registered for the given format, or {@code null} if
          * not found.
          * @param fmt format to obtain a handler for
          * @return first handler registered for the format
@@ -378,9 +378,9 @@ public class BoundaryIOManager<
             return null;
         }
 
-        /** Get the first handler registered for the given file extension or null if not found.
+        /** Get the first handler registered for the given file extension or {@code null} if not found.
          * @param fileExt file extension
-         * @return first handler registered for the given file extension or null if not found
+         * @return first handler registered for the given file extension or {@code null} if not found
          */
         public synchronized T getByFileExtension(final String fileExt) {
             return getByNormalizedKey(handlersByFileExtension, fileExt);
@@ -391,7 +391,7 @@ public class BoundaryIOManager<
          * and the {@code fileName} argument is ignored. Otherwise, the file extension is extracted
          * from {@code fileName} and used to look up the handler.
          * @param fmt format to look up; if present, {@code fileName} is ignored
-         * @param fileName file name to use for the look-up if {@code fmt} is null
+         * @param fileName file name to use for the look-up if {@code fmt} is {@code null}
          * @return the handler matching the arguments
          * @throws IllegalArgumentException if a handler cannot be found
          */
@@ -425,7 +425,7 @@ public class BoundaryIOManager<
         /** Add the handler to the internal format name map.
          * @param fmtName format name
          * @param handler handler to add
-         * @throws NullPointerException if {@code fmtName} is null
+         * @throws NullPointerException if {@code fmtName} is {@code null}
          */
         private void addToFormat(final String fmtName, final T handler) {
             Objects.requireNonNull(fmtName, FORMAT_NAME_NULL_ERR);
@@ -454,12 +454,12 @@ public class BoundaryIOManager<
             }
         }
 
-        /** Normalize the given key and return its associated value in the map, or null
+        /** Normalize the given key and return its associated value in the map, or {@code null}
          * if not found.
          * @param <V> Value type
          * @param map map to search
          * @param key unnormalized map key
-         * @return the value associated with the key after normalization, or null if not found
+         * @return the value associated with the key after normalization, or {@code null} if not found
          */
         private static <V> V getByNormalizedKey(final Map<String, V> map, final String key) {
             if (key != null) {

--- a/commons-geometry-io-core/src/main/java/org/apache/commons/geometry/io/core/GeometryIOMetadata.java
+++ b/commons-geometry-io-core/src/main/java/org/apache/commons/geometry/io/core/GeometryIOMetadata.java
@@ -23,13 +23,13 @@ import java.nio.charset.Charset;
 public interface GeometryIOMetadata {
 
     /** Get the file name associated with the operation, if any.
-     * @return file name associated with the operation or null
+     * @return file name associated with the operation or {@code null}
      *      if unknown or not applicable
      */
     String getFileName();
 
     /** Get the charset for the operation, if any.
-     * @return charset for the operation or null if unknown or
+     * @return charset for the operation or {@code null} if unknown or
      *      not applicable
      */
     Charset getCharset();

--- a/commons-geometry-io-core/src/main/java/org/apache/commons/geometry/io/core/internal/CharReadBuffer.java
+++ b/commons-geometry-io-core/src/main/java/org/apache/commons/geometry/io/core/internal/CharReadBuffer.java
@@ -55,7 +55,7 @@ public class CharReadBuffer {
 
     /** Construct a new instance that buffers characters from the given reader.
      * @param reader underlying reader instance
-     * @throws NullPointerException if {@code reader} is null
+     * @throws NullPointerException if {@code reader} is {@code null}
      */
     public CharReadBuffer(final Reader reader) {
         this(checkReader(reader), DEFAULT_INITIAL_CAPACITY, DEFAULT_INITIAL_CAPACITY >>> 1, false);
@@ -65,7 +65,7 @@ public class CharReadBuffer {
      * @param reader underlying reader instance
      * @param initialCapacity the initial capacity of the internal buffer; the buffer
      *      is resized as needed
-     * @throws NullPointerException if {@code reader} is null
+     * @throws NullPointerException if {@code reader} is {@code null}
      * @throws IllegalArgumentException if {@code initialCapacity} is less than one.
      */
     public CharReadBuffer(final Reader reader, final int initialCapacity) {
@@ -79,7 +79,7 @@ public class CharReadBuffer {
      * @param minRead the minimum number of characters to request from the reader
      *      when fetching more characters into the buffer; this can be used to limit the
      *      number of calls made to the reader
-     * @throws NullPointerException if {@code reader} is null
+     * @throws NullPointerException if {@code reader} is {@code null}
      * @throws IllegalArgumentException if {@code initialCapacity} or {@code minRead}
      *      are less than one.
      */
@@ -183,7 +183,7 @@ public class CharReadBuffer {
      * the number of characters available in the buffer up to {@code len}. Null is
      * returned if no more characters are available.
      * @param len requested length of the string
-     * @return a string from the read buffer or null if no more characters are available
+     * @return a string from the read buffer or {@code null} if no more characters are available
      * @throws IllegalArgumentException if {@code len} is less than 0
      * @throws java.io.UncheckedIOException if an I/O error occurs
      * @see #peekString(int)
@@ -214,7 +214,7 @@ public class CharReadBuffer {
      * the number of characters available in the buffer up to {@code len}. Null is
      * returned if no more characters are available.
      * @param len requested length of the string
-     * @return a string from the read buffer or null if no more characters are available
+     * @return a string from the read buffer or {@code null} if no more characters are available
      * @throws IllegalArgumentException if {@code len} is less than 0
      * @throws java.io.UncheckedIOException if an I/O error occurs
      * @see #readString(int)

--- a/commons-geometry-io-core/src/main/java/org/apache/commons/geometry/io/core/internal/GeometryIOUtils.java
+++ b/commons-geometry-io-core/src/main/java/org/apache/commons/geometry/io/core/internal/GeometryIOUtils.java
@@ -45,7 +45,7 @@ public final class GeometryIOUtils {
     /** Utility class; no instantiation. */
     private GeometryIOUtils() {}
 
-    /** Get the file name of the given path or null if one does not exist
+    /** Get the file name of the given path or {@code null} if one does not exist
      * or is the empty string.
      * @param path path to get the file name of
      * @return file name of the given path
@@ -58,7 +58,7 @@ public final class GeometryIOUtils {
         return null;
     }
 
-    /** Get the file name of the given url or null if one does not exist or is
+    /** Get the file name of the given url or {@code null} if one does not exist or is
      * the empty string.
      * @param url url to get the file name of
      * @return file name of the given url
@@ -73,10 +73,10 @@ public final class GeometryIOUtils {
 
     /** Get the file name from the given path string, defined as
      * the substring following the last path separator character.
-     * Null is returned if the argument is null or the file name is
+     * {@code null} is returned if the argument is {@code null} or the file name is
      * the empty string.
      * @param path path to get the file name from
-     * @return file name of the given path string or null if a
+     * @return file name of the given path string or {@code null} if a
      *      non-empty file name does not exist
      */
     public static String getFileName(final String path) {
@@ -96,7 +96,7 @@ public final class GeometryIOUtils {
     /** Get the part of the file name after the last dot.
      * @param fileName file name to get the extension for
      * @return the extension of the file name, the empty string if no extension is found, or
-     *      null if the argument is null
+     *      null if the argument is {@code null}
      */
     public static String getFileExtension(final String fileName) {
         if (fileName != null) {
@@ -112,7 +112,7 @@ public final class GeometryIOUtils {
     }
 
     /** Create a {@link BufferedReader} for reading from the given input. The charset used is the charset
-     * defined in {@code input} or {@code defaultCharset} if null.
+     * defined in {@code input} or {@code defaultCharset} if {@code null}.
      * @param input input to read from
      * @param defaultCharset charset to use if no charset is defined in the input
      * @return new reader instance
@@ -127,7 +127,7 @@ public final class GeometryIOUtils {
     }
 
     /** Create a {@link BufferedWriter} for writing to the given output. The charset used is the charset
-     * defined in {@code output} or {@code defaultCharset} if null.
+     * defined in {@code output} or {@code defaultCharset} if {@code null}.
      * @param output output to write to
      * @param defaultCharset charset to use if no charset is defined in the output
      * @return new writer instance

--- a/commons-geometry-io-core/src/main/java/org/apache/commons/geometry/io/core/internal/SimpleTextParser.java
+++ b/commons-geometry-io-core/src/main/java/org/apache/commons/geometry/io/core/internal/SimpleTextParser.java
@@ -633,7 +633,7 @@ public class SimpleTextParser {
      * string has the specified length or the end of the stream is reached.
      * @param len the maximum length of the returned string
      * @return a string containing at most {@code len} characters from the stream
-     *      or null if the parser has already reached the end of the stream
+     *      or {@code null} if the parser has already reached the end of the stream
      * @throws IllegalArgumentException if {@code len} is less than 0 or greater than the
      *      configured {@link #getMaxStringLength() maximum string length}
      * @throws java.io.UncheckedIOException if an I/O error occurs
@@ -649,7 +649,7 @@ public class SimpleTextParser {
      * change the current token or advance the parser position.
      * @param pred predicate function passed characters read from the input; reading continues
      *      until the predicate returns false
-     * @return string containing characters matching {@code pred} or null if the parser has already
+     * @return string containing characters matching {@code pred} or {@code null} if the parser has already
      *      reached the end of the stream
      * @throws IllegalStateException if the length of the produced string exceeds the configured
      *      {@link #getMaxStringLength() maximum string length}

--- a/commons-geometry-io-euclidean/src/main/java/org/apache/commons/geometry/io/euclidean/threed/BoundaryIOManager3D.java
+++ b/commons-geometry-io-euclidean/src/main/java/org/apache/commons/geometry/io/euclidean/threed/BoundaryIOManager3D.java
@@ -59,7 +59,7 @@ public class BoundaryIOManager3D extends BoundaryIOManager<
 
     /** Get a {@link FacetDefinitionReader} for reading facet information from the given input.
      * @param in input to read facets from
-     * @param fmt format of the input; if null, the format is determined implicitly from the
+     * @param fmt format of the input; if {@code null}, the format is determined implicitly from the
      *      file extension of the input {@link GeometryInput#getFileName() file name}
      * @return facet definition reader
      * @throws IllegalArgumentException if no read handler can be found for the input format
@@ -84,7 +84,7 @@ public class BoundaryIOManager3D extends BoundaryIOManager<
      *  <li>{@link java.io.UncheckedIOException UncheckedIOException} if an I/O error occurs</li>
      * </ul>
      * @param in input to read from
-     * @param fmt format of the input; if null, the format is determined implicitly from the
+     * @param fmt format of the input; if {@code null}, the format is determined implicitly from the
      *      file extension of the input {@link GeometryInput#getFileName() file name}
      * @return stream providing access to the facets in the input
      * @throws IllegalArgumentException if no read handler can be found for the input format
@@ -110,7 +110,7 @@ public class BoundaryIOManager3D extends BoundaryIOManager<
      *  <li>{@link java.io.UncheckedIOException UncheckedIOException} if an I/O error occurs</li>
      * </ul>
      * @param in input to read from
-     * @param fmt format of the input; if null, the format is determined implicitly from the
+     * @param fmt format of the input; if {@code null}, the format is determined implicitly from the
      *      file extension of the input {@link GeometryInput#getFileName() file name}
      * @param precision precision context used for floating point comparisons
      * @return stream providing access to the triangles in the input
@@ -126,7 +126,7 @@ public class BoundaryIOManager3D extends BoundaryIOManager<
 
     /** Return a {@link TriangleMesh} containing all triangles from the given input.
      * @param in input to read from
-     * @param fmt format of the input; if null, the format is determined implicitly from the
+     * @param fmt format of the input; if {@code null}, the format is determined implicitly from the
      *      file extension of the input {@link GeometryInput#getFileName() file name}
      * @param precision precision context used for floating point comparisons
      * @return mesh containing all triangles from the input
@@ -147,7 +147,7 @@ public class BoundaryIOManager3D extends BoundaryIOManager<
      * try-with-resources statement outside of this method.</p>
      * @param boundaries stream containing boundaries to write
      * @param out output to write to
-     * @param fmt format of the output; if null, the format is determined implicitly from the
+     * @param fmt format of the output; if {@code null}, the format is determined implicitly from the
      *      file extension of the output {@link GeometryOutput#getFileName() file name}
      * @throws IllegalArgumentException if no write handler can be found for the output format
      * @throws java.io.UncheckedIOException if an I/O error occurs
@@ -164,7 +164,7 @@ public class BoundaryIOManager3D extends BoundaryIOManager<
      * try-with-resources statement outside of this method.</p>
      * @param facets stream containing facets to write
      * @param out output to write to
-     * @param fmt format of the output; if null, the format is determined implicitly from the
+     * @param fmt format of the output; if {@code null}, the format is determined implicitly from the
      *      file extension of the output {@link GeometryOutput#getFileName() file name}
      * @throws IllegalArgumentException if no write handler can be found for the output format
      * @throws java.io.UncheckedIOException if an I/O error occurs
@@ -177,7 +177,7 @@ public class BoundaryIOManager3D extends BoundaryIOManager<
     /** Write the given facets to the output.
      * @param facets facets to write
      * @param out output to write to
-     * @param fmt format of the output; if null, the format is determined implicitly from the
+     * @param fmt format of the output; if {@code null}, the format is determined implicitly from the
      *      file extension of the output {@link GeometryOutput#getFileName() file name}
      * @throws IllegalArgumentException if no write handler can be found for the output format
      * @throws java.io.UncheckedIOException if an I/O error occurs

--- a/commons-geometry-io-euclidean/src/main/java/org/apache/commons/geometry/io/euclidean/threed/FacetDefinition.java
+++ b/commons-geometry-io-euclidean/src/main/java/org/apache/commons/geometry/io/euclidean/threed/FacetDefinition.java
@@ -39,10 +39,10 @@ public interface FacetDefinition {
      */
     List<Vector3D> getVertices();
 
-    /** Get the normal defined for the facet or null if one has not been explicitly
+    /** Get the normal defined for the facet or {@code null} if one has not been explicitly
      * specified. No guarantees are made regarding the properties of the normal
      * or its relationship to the vertices.
-     * @return the defined normal for the facet or null if one has not been explicitly
+     * @return the defined normal for the facet or {@code null} if one has not been explicitly
      *      specified
      */
     Vector3D getNormal();

--- a/commons-geometry-io-euclidean/src/main/java/org/apache/commons/geometry/io/euclidean/threed/FacetDefinitionReader.java
+++ b/commons-geometry-io-euclidean/src/main/java/org/apache/commons/geometry/io/euclidean/threed/FacetDefinitionReader.java
@@ -21,9 +21,9 @@ package org.apache.commons.geometry.io.euclidean.threed;
  */
 public interface FacetDefinitionReader extends AutoCloseable {
 
-    /** Return the next facet definition from the input source or null if no more
+    /** Return the next facet definition from the input source or {@code null} if no more
      * facets are available.
-     * @return the next facet definition or null if no more facets
+     * @return the next facet definition or {@code null} if no more facets
      *      are available
      * @throws IllegalStateException if a data format error occurs
      * @throws java.io.UncheckedIOException if an I/O error occurs

--- a/commons-geometry-io-euclidean/src/main/java/org/apache/commons/geometry/io/euclidean/threed/FacetDefinitions.java
+++ b/commons-geometry-io-euclidean/src/main/java/org/apache/commons/geometry/io/euclidean/threed/FacetDefinitions.java
@@ -36,7 +36,7 @@ public final class FacetDefinitions {
      * polygon point in a similar (but not necessarily equal) direction, reversing the
      * order of vertices if needed.
      * @param vertices facet vertices
-     * @param normal facet normal; may be null
+     * @param normal facet normal; may be {@code null}
      * @param precision precision context used for floating point comparisons
      * @return convex polygon constructed from the vertices and normal
      * @throws IllegalArgumentException if a valid convex polygon cannot be constructed
@@ -59,7 +59,7 @@ public final class FacetDefinitions {
      * @param facet facet to convert to a polygon instance
      * @param precision precision context used for floating point comparisons
      * @return convex polygon constructed from the facet
-     * @throws NullPointerException if either argument is null
+     * @throws NullPointerException if either argument is {@code null}
      * @throws IllegalArgumentException if a valid convex polygon cannot be constructed
      */
     public static ConvexPolygon3D toPolygon(final FacetDefinition facet, final Precision.DoubleEquivalence precision) {

--- a/commons-geometry-io-euclidean/src/main/java/org/apache/commons/geometry/io/euclidean/threed/IO3D.java
+++ b/commons-geometry-io-euclidean/src/main/java/org/apache/commons/geometry/io/euclidean/threed/IO3D.java
@@ -89,7 +89,7 @@ public final class IO3D {
 
     /** Get a {@link FacetDefinitionReader} for reading facet information from the given input.
      * @param in input to read from
-     * @param fmt format of the input; if null, the format is determined implicitly from the
+     * @param fmt format of the input; if {@code null}, the format is determined implicitly from the
      *      file extension of the input {@link GeometryInput#getFileName() file name}
      * @return facet definition reader
      * @throws IllegalArgumentException if no handler has been registered with the
@@ -174,7 +174,7 @@ public final class IO3D {
      *      <li>{@link java.io.UncheckedIOException UncheckedIOException} if an I/O error occurs</li>
      *  </ul>
      * @param in input to read from
-     * @param fmt format of the input; if null, the format is determined implicitly from the
+     * @param fmt format of the input; if {@code null}, the format is determined implicitly from the
      *      file extension of the input {@link GeometryInput#getFileName() file name}
      * @return stream providing access to the facets in the input
      * @throws IllegalArgumentException if no read handler has been registered with the
@@ -264,7 +264,7 @@ public final class IO3D {
      *      <li>{@link java.io.UncheckedIOException UncheckedIOException} if an I/O error occurs</li>
      *  </ul>
      * @param in input to read boundaries from
-     * @param fmt format of the input; if null, the format is determined implicitly from the
+     * @param fmt format of the input; if {@code null}, the format is determined implicitly from the
      *      file extension of the input {@link GeometryInput#getFileName() file name}
      * @param precision precision context used for floating point comparisons
      * @return stream providing access to the boundaries in the input
@@ -356,7 +356,7 @@ public final class IO3D {
      *      <li>{@link java.io.UncheckedIOException UncheckedIOException} if an I/O error occurs</li>
      *  </ul>
      * @param in input to read from
-     * @param fmt format of the input; if null, the format is determined implicitly from the
+     * @param fmt format of the input; if {@code null}, the format is determined implicitly from the
      *      file extension of the input {@link GeometryInput#getFileName() file name}
      * @param precision precision context used for floating point comparisons
      * @return stream providing access to the triangles in the input
@@ -406,7 +406,7 @@ public final class IO3D {
     /** Return a {@link BoundarySource3D} containing all boundaries from the given input. A runtime
      * exception may be thrown if mathematically invalid boundaries are encountered.
      * @param in input to read boundaries from
-     * @param fmt format of the input; if null, the format is determined implicitly from the
+     * @param fmt format of the input; if {@code null}, the format is determined implicitly from the
      *      file extension of the input {@link GeometryInput#getFileName() file name}
      * @param precision precision context used for floating point comparisons
      * @return object containing all boundaries from the input
@@ -456,7 +456,7 @@ public final class IO3D {
     /** Return a {@link TriangleMesh} containing all triangles from the given input. A runtime exception
      * may be thrown if mathematically invalid boundaries are encountered.
      * @param in input to read from
-     * @param fmt format of the input; if null, the format is determined implicitly from the
+     * @param fmt format of the input; if {@code null}, the format is determined implicitly from the
      *      file extension of the input {@link GeometryInput#getFileName() file name}
      * @param precision precision context used for floating point comparisons
      * @return a mesh containing all triangles from the input
@@ -493,7 +493,7 @@ public final class IO3D {
      * in a try-with-resources statement outside of this method if the stream is required to be closed.</p>
      * @param boundaries stream containing boundaries to write
      * @param out output to write to
-     * @param fmt format of the output; if null, the format is determined implicitly from the
+     * @param fmt format of the output; if {@code null}, the format is determined implicitly from the
      *      file extension of the output {@link GeometryOutput#getFileName() file name}
      * @throws IllegalArgumentException if no write handler is registered with the
      *      {@link #getDefaultManager() default manager} for the output format
@@ -523,7 +523,7 @@ public final class IO3D {
     /** Write all boundaries from {@code src} to the given output.
      * @param src boundary source containing the boundaries to write
      * @param out output to write to
-     * @param fmt format of the output; if null, the format is determined implicitly from the
+     * @param fmt format of the output; if {@code null}, the format is determined implicitly from the
      *      file extension of the output {@link GeometryOutput#getFileName() file name}
      * @throws IllegalArgumentException if no write handler is registered with the
      *      {@link #getDefaultManager() default manager} for the output format
@@ -551,7 +551,7 @@ public final class IO3D {
     /** Write the given collection of facets to the output.
      * @param facets facets to write
      * @param out output to write to
-     * @param fmt format of the output; if null, the format is determined implicitly from the
+     * @param fmt format of the output; if {@code null}, the format is determined implicitly from the
      *      file extension of the output {@link GeometryOutput#getFileName() file name}
      * @throws IllegalArgumentException if no write handler is registered with the
      *      {@link #getDefaultManager() default manager} for the output format
@@ -585,7 +585,7 @@ public final class IO3D {
      * in a try-with-resources statement outside of this method if the stream is required to be closed.</p>
      * @param facets stream containing facets to write
      * @param out output to write to
-     * @param fmt format of the output; if null, the format is determined implicitly from the
+     * @param fmt format of the output; if {@code null}, the format is determined implicitly from the
      *      file extension of the output {@link GeometryOutput#getFileName() file name}
      * @throws IllegalArgumentException if no write handler is registered with the
      *      {@link #getDefaultManager() default manager} for the output format

--- a/commons-geometry-io-euclidean/src/main/java/org/apache/commons/geometry/io/euclidean/threed/obj/AbstractObjParser.java
+++ b/commons-geometry-io-euclidean/src/main/java/org/apache/commons/geometry/io/euclidean/threed/obj/AbstractObjParser.java
@@ -40,8 +40,8 @@ public abstract class AbstractObjParser {
     }
 
     /** Get the current keyword, meaning the keyword most recently parsed via the {@link #nextKeyword()}
-     * method. Null is returned if parsing has not started or the end of the content has been reached.
-     * @return the current keyword or null if parsing has not started or the end
+     * method. {@code null} is returned if parsing has not started or the end of the content has been reached.
+     * @return the current keyword or {@code null} if parsing has not started or the end
      *      of the content has been reached
      */
     public String getCurrentKeyword() {
@@ -92,7 +92,7 @@ public abstract class AbstractObjParser {
 
     /** Read the remaining content on the current data line, taking line continuation characters into
      * account.
-     * @return remaining content on the current data line or null if the end of the content has
+     * @return remaining content on the current data line or {@code null} if the end of the content has
      *      been reached
      * @throws java.io.UncheckedIOException if an I/O error occurs
      */

--- a/commons-geometry-io-euclidean/src/main/java/org/apache/commons/geometry/io/euclidean/threed/obj/AbstractObjPolygonReader.java
+++ b/commons-geometry-io-euclidean/src/main/java/org/apache/commons/geometry/io/euclidean/threed/obj/AbstractObjPolygonReader.java
@@ -68,8 +68,8 @@ public abstract class AbstractObjPolygonReader implements Closeable {
         GeometryIOUtils.closeUnchecked(reader);
     }
 
-    /** Return the next face from the OBJ content or null if no face is found.
-     * @return the next face from the OBJ content or null if no face is found
+    /** Return the next face from the OBJ content or {@code null} if no face is found.
+     * @return the next face from the OBJ content or {@code null} if no face is found
      * @throws IllegalStateException if a parsing error occurs
      * @throws java.io.UncheckedIOException if an I/O error occurs
      */

--- a/commons-geometry-io-euclidean/src/main/java/org/apache/commons/geometry/io/euclidean/threed/obj/PolygonObjParser.java
+++ b/commons-geometry-io-euclidean/src/main/java/org/apache/commons/geometry/io/euclidean/threed/obj/PolygonObjParser.java
@@ -305,11 +305,11 @@ public class PolygonObjParser extends AbstractObjParser {
         }
 
         /** Get a composite normal for the face by computing the sum of all defined vertex
-         * normals and normalizing the result. Null is returned if no vertex normals are
+         * normals and normalizing the result. {@code null} is returned if no vertex normals are
          * defined or the defined normals sum to zero.
          * @param modelNormalFn function used to access normals parsed earlier in the model;
          *      callers are responsible for storing these values as they are parsed
-         * @return composite face normal or null if no composite normal can be determined from the
+         * @return composite face normal or {@code null} if no composite normal can be determined from the
          *      normals defined for the face
          */
         public Vector3D getDefinedCompositeNormal(final IntFunction<Vector3D> modelNormalFn) {
@@ -327,12 +327,12 @@ public class PolygonObjParser extends AbstractObjParser {
         }
 
         /** Compute a normal for the face using its first three vertices. The vertices will wind in a
-         * counter-clockwise direction when viewed looking down the returned normal. Null is returned
+         * counter-clockwise direction when viewed looking down the returned normal. {@code null} is returned
          * if the normal could not be determined, which would be the case if the vertices lie in the
          * same line or two or more are equal.
          * @param modelVertexFn function used to access model vertices parsed earlier in the content;
          *      callers are responsible for storing these values as they are passed
-         * @return a face normal computed from the first 3 vertices or null if a normal cannot
+         * @return a face normal computed from the first 3 vertices or {@code null} if a normal cannot
          *      be determined
          */
         public Vector3D computeNormalFromVertices(final IntFunction<Vector3D> modelVertexFn) {
@@ -345,8 +345,8 @@ public class PolygonObjParser extends AbstractObjParser {
 
         /** Get the vertex attributes for the face listed in the order that produces a counter-clockwise
          * winding of vertices when viewed looking down the given normal direction. If {@code normal}
-         * is null, the original vertex sequence is used.
-         * @param normal requested face normal; may be null
+         * is {@code null}, the original vertex sequence is used.
+         * @param normal requested face normal; may be {@code null}
          * @param modelVertexFn function used to access model vertices parsed earlier in the content;
          *      callers are responsible for storing these values as they are passed
          * @return list of vertex attributes for the face, oriented to correspond with the given

--- a/commons-geometry-io-euclidean/src/main/java/org/apache/commons/geometry/io/euclidean/threed/stl/BinaryStlWriter.java
+++ b/commons-geometry-io-euclidean/src/main/java/org/apache/commons/geometry/io/euclidean/threed/stl/BinaryStlWriter.java
@@ -40,10 +40,10 @@ public class BinaryStlWriter implements Closeable {
         this.out = out;
     }
 
-    /** Write binary STL header content. If {@code headerContent} is null, the written header
+    /** Write binary STL header content. If {@code headerContent} is {@code null}, the written header
      * will consist entirely of zeros. Otherwise, up to 80 bytes from {@code headerContent}
      * are written to the header, with any remaining bytes of the header filled with zeros.
-     * @param headerContent bytes to include in the header; may be null
+     * @param headerContent bytes to include in the header; may be {@code null}
      * @param triangleCount number of triangles to be included in the content
      * @throws java.io.UncheckedIOException if an I/O error occurs
      */
@@ -62,7 +62,7 @@ public class BinaryStlWriter implements Closeable {
      * @param p1 first point
      * @param p2 second point
      * @param p3 third point
-     * @param normal triangle normal; may be null
+     * @param normal triangle normal; may be {@code null}
      * @throws java.io.UncheckedIOException if an I/O error occurs
      */
     public void writeTriangle(final Vector3D p1, final Vector3D p2, final Vector3D p3,
@@ -82,7 +82,7 @@ public class BinaryStlWriter implements Closeable {
      * @param p1 first point
      * @param p2 second point
      * @param p3 third point
-     * @param normal triangle normal; may be null
+     * @param normal triangle normal; may be {@code null}
      * @param attributeValue 2-byte STL triangle attribute value
      * @throws java.io.UncheckedIOException if an I/O error occurs
      */
@@ -122,7 +122,7 @@ public class BinaryStlWriter implements Closeable {
     }
 
     /** Write binary STL header content to the given output stream. If {@code headerContent}
-     * is null, the written header will consist entirely of zeros. Otherwise, up to 80 bytes
+     * is {@code null}, the written header will consist entirely of zeros. Otherwise, up to 80 bytes
      * from {@code headerContent} are written to the header, with any remaining bytes of the
      * header filled with zeros.
      * @param headerContent

--- a/commons-geometry-io-euclidean/src/main/java/org/apache/commons/geometry/io/euclidean/threed/stl/StlFacetDefinitionReaders.java
+++ b/commons-geometry-io-euclidean/src/main/java/org/apache/commons/geometry/io/euclidean/threed/stl/StlFacetDefinitionReaders.java
@@ -40,7 +40,7 @@ public final class StlFacetDefinitionReaders {
      * or text file and an appropriate reader is returned.
      * @param in input to read from
      * @param charset charset to use when checking the input for text content;
-     *      if null, the input is assumed to use the UTF-8 charset
+     *      if {@code null}, the input is assumed to use the UTF-8 charset
      * @return facet definition reader
      * @throws IllegalStateException if a parsing error occurs
      * @throws java.io.UncheckedIOException if an I/O error occurs

--- a/commons-geometry-io-euclidean/src/main/java/org/apache/commons/geometry/io/euclidean/threed/stl/StlUtils.java
+++ b/commons-geometry-io-euclidean/src/main/java/org/apache/commons/geometry/io/euclidean/threed/stl/StlUtils.java
@@ -43,7 +43,7 @@ final class StlUtils {
      * @param p1 first point
      * @param p2 second point
      * @param p3 third point
-     * @param normal defined triangle normal; may be null
+     * @param normal defined triangle normal; may be {@code null}
      * @return STL normal for the triangle
      */
     static Vector3D determineNormal(final Vector3D p1, final Vector3D p2, final Vector3D p3,
@@ -64,12 +64,12 @@ final class StlUtils {
     }
 
     /** Return true if the given points are arranged counter-clockwise relative to the
-     * given normal. Returns true if {@code normal} is null.
+     * given normal. Returns true if {@code normal} is {@code null}.
      * @param p1 first point
      * @param p2 second point
      * @param p3 third point
-     * @param normal normal; may be null, in which case the zero vector is used
-     * @return true if {@code normal} is null or if the given points are arranged counter-clockwise
+     * @param normal normal; may be {@code null}, in which case the zero vector is used
+     * @return true if {@code normal} is {@code null} or if the given points are arranged counter-clockwise
      *      relative to {@code normal}
      */
     static boolean pointsAreCounterClockwise(final Vector3D p1, final Vector3D p2, final Vector3D p3,
@@ -84,12 +84,12 @@ final class StlUtils {
         return true;
     }
 
-    /** Get the normal using the right-hand rule for the given triangle vertices. Null is returned
+    /** Get the normal using the right-hand rule for the given triangle vertices. {@code null} is returned
      * if the normal could not be computed.
      * @param p1 first point
      * @param p2 second point
      * @param p3 third point
-     * @return the normal for the given triangle vertices or null if one could not be computed
+     * @return the normal for the given triangle vertices or {@code null} if one could not be computed
      */
     private static Vector3D computeTriangleNormal(final Vector3D p1, final Vector3D p2, final Vector3D p3) {
         final Vector3D normal = p1.vectorTo(p2).cross(p1.vectorTo(p3)).normalizeOrNull();

--- a/commons-geometry-io-euclidean/src/main/java/org/apache/commons/geometry/io/euclidean/threed/stl/TextStlFacetDefinitionReader.java
+++ b/commons-geometry-io-euclidean/src/main/java/org/apache/commons/geometry/io/euclidean/threed/stl/TextStlFacetDefinitionReader.java
@@ -54,8 +54,8 @@ public class TextStlFacetDefinitionReader implements FacetDefinitionReader {
         this.parser = new SimpleTextParser(reader);
     }
 
-    /** Get the name of the STL solid being read or null if no name was specified.
-     * @return the name of the STL solid being read or null if no name was specified
+    /** Get the name of the STL solid being read or {@code null} if no name was specified.
+     * @return the name of the STL solid being read or {@code null} if no name was specified
      * @throws IllegalStateException if a data format error occurs
      * @throws java.io.UncheckedIOException if an I/O error occurs
      */
@@ -189,10 +189,10 @@ public class TextStlFacetDefinitionReader implements FacetDefinitionReader {
                 .getCurrentTokenAsDouble();
     }
 
-    /** Return a trimmed version of the given string or null if the string contains
+    /** Return a trimmed version of the given string or {@code null} if the string contains
      * only whitespace.
      * @param str input stream
-     * @return a trimmed version of the given string or null if the string contains only
+     * @return a trimmed version of the given string or {@code null} if the string contains only
      *      whitespace
      */
     private static String trimmedOrNull(final String str) {

--- a/commons-geometry-io-euclidean/src/main/java/org/apache/commons/geometry/io/euclidean/threed/txt/TextFacetDefinitionReader.java
+++ b/commons-geometry-io-euclidean/src/main/java/org/apache/commons/geometry/io/euclidean/threed/txt/TextFacetDefinitionReader.java
@@ -166,7 +166,7 @@ public class TextFacetDefinitionReader implements FacetDefinitionReader {
 
     /** Internal method to read a facet definition starting from the current parser
      * position. Empty lines (including lines containing only comments) are discarded.
-     * @return facet definition or null if the end of input is reached
+     * @return facet definition or {@code null} if the end of input is reached
      * @throws IllegalStateException if a data format error occurs
      * @throws java.io.UncheckedIOException if an I/O error occurs
      */

--- a/commons-geometry-io-euclidean/src/main/java/org/apache/commons/geometry/io/euclidean/threed/txt/TextFacetDefinitionWriter.java
+++ b/commons-geometry-io-euclidean/src/main/java/org/apache/commons/geometry/io/euclidean/threed/txt/TextFacetDefinitionWriter.java
@@ -99,7 +99,7 @@ public class TextFacetDefinitionWriter extends AbstractTextFormatWriter {
     /** Number of vertices required per facet; will be -1 if disabled. */
     private int facetVertexCount = DEFAULT_FACET_VERTEX_COUNT;
 
-    /** Comment start token; may be null. */
+    /** Comment start token; may be {@code null}. */
     private String commentToken = DEFAULT_COMMENT_TOKEN;
 
     /** Construct a new instance that writes facet information to the given writer.
@@ -165,7 +165,7 @@ public class TextFacetDefinitionWriter extends AbstractTextFormatWriter {
 
     /** Get the string used to begin comment lines in the output.
      * The default value is {@value #DEFAULT_COMMENT_TOKEN}
-     * @return the string used to begin comment lines in the output; may be null
+     * @return the string used to begin comment lines in the output; may be {@code null}
      */
     public String getCommentToken() {
         return commentToken;
@@ -191,7 +191,7 @@ public class TextFacetDefinitionWriter extends AbstractTextFormatWriter {
 
     /** Write a comment to the output.
      * @param comment comment string to write
-     * @throws IllegalStateException if the configured {@link #getCommentToken() comment token} is null
+     * @throws IllegalStateException if the configured {@link #getCommentToken() comment token} is {@code null}
      * @throws java.io.UncheckedIOException if an I/O error occurs
      */
     public void writeComment(final String comment) {

--- a/commons-geometry-spherical/src/main/java/org/apache/commons/geometry/spherical/PointMap1SImpl.java
+++ b/commons-geometry-spherical/src/main/java/org/apache/commons/geometry/spherical/PointMap1SImpl.java
@@ -38,10 +38,10 @@ import org.apache.commons.numbers.core.Precision;
 final class PointMap1SImpl<V>
     extends AbstractPointMap1D<Point1S, V> {
 
-    /** Minimum key in the map, or null if not known. */
+    /** Minimum key in the map, or {@code null} if not known. */
     private Point1S minKey;
 
-    /** Maximum key in the map, or null if not known. */
+    /** Maximum key in the map, or {@code null} if not known. */
     private Point1S maxKey;
 
     /** Modification version of the map. */
@@ -210,7 +210,7 @@ final class PointMap1SImpl<V>
     /** Null-safe method to get the value from a map entry.
      * @param <V> Value type
      * @param entry map entry
-     * @return map value or null if {@code entry} is null
+     * @return map value or {@code null} if {@code entry} is {@code null}
      */
     private static <V> V getValue(final Entry<?, V> entry) {
         return entry != null ?
@@ -406,7 +406,7 @@ final class PointMap1SImpl<V>
         /** Get a {@link DistancedValue} instance containing the next entry from the given
          * iterator.
          * @param it iterator to get the next value from
-         * @return distanced value containing the next entry from the iterator or null if the iterator
+         * @return distanced value containing the next entry from the iterator or {@code null} if the iterator
          *      does not contain any more elements
          */
         private DistancedValue<Entry<Point1S, V>> getNextEntry(final Iterator<Entry<Point1S, V>> it) {

--- a/commons-geometry-spherical/src/main/java/org/apache/commons/geometry/spherical/oned/AngularInterval.java
+++ b/commons-geometry-spherical/src/main/java/org/apache/commons/geometry/spherical/oned/AngularInterval.java
@@ -91,9 +91,9 @@ public class AngularInterval implements HyperplaneBoundedRegion<Point1S> {
                 0.0;
     }
 
-    /** Get the minimum boundary for the interval, or null if the
+    /** Get the minimum boundary for the interval, or {@code null} if the
      * interval represents the full space.
-     * @return the minimum point for the interval or null if
+     * @return the minimum point for the interval or {@code null} if
      *      the interval represents the full space
      */
     public CutAngle getMinBoundary() {
@@ -111,18 +111,18 @@ public class AngularInterval implements HyperplaneBoundedRegion<Point1S> {
                 Angle.TWO_PI;
     }
 
-    /** Get the maximum point for the interval. This will be null if the
+    /** Get the maximum point for the interval. This will be {@code null} if the
      * interval represents the full space.
-     * @return the maximum point for the interval or null if
+     * @return the maximum point for the interval or {@code null} if
      *      the interval represents the full space
      */
     public CutAngle getMaxBoundary() {
         return maxBoundary;
     }
 
-    /** Get the midpoint of the interval or null if the interval represents
+    /** Get the midpoint of the interval or {@code null} if the interval represents
      *  the full space.
-     * @return the midpoint of the interval or null if the interval represents
+     * @return the midpoint of the interval or {@code null} if the interval represents
      *      the full space
      * @see #getCentroid()
      */

--- a/commons-geometry-spherical/src/main/java/org/apache/commons/geometry/spherical/oned/Point1S.java
+++ b/commons-geometry-spherical/src/main/java/org/apache/commons/geometry/spherical/oned/Point1S.java
@@ -259,7 +259,7 @@ public final class Point1S implements Point<Point1S> {
      *
      * @param other Object to test for equality to this
      * @return true if two points on the 1-sphere objects are exactly equal, false if
-     *         object is null, not an instance of Point1S, or
+     *         object is {@code null}, not an instance of Point1S, or
      *         not equal to this Point1S instance
      *
      */

--- a/commons-geometry-spherical/src/main/java/org/apache/commons/geometry/spherical/oned/RegionBSPTree1S.java
+++ b/commons-geometry-spherical/src/main/java/org/apache/commons/geometry/spherical/oned/RegionBSPTree1S.java
@@ -418,7 +418,7 @@ public class RegionBSPTree1S extends AbstractRegionBSPTree<Point1S, RegionBSPTre
     }
 
     /** Perform a union operation with {@code target} and {@code input}, storing the result
-     * in {@code target}; does nothing if {@code input} is null.
+     * in {@code target}; does nothing if {@code input} is {@code null}.
      * @param target target tree
      * @param input input tree
      */

--- a/commons-geometry-spherical/src/main/java/org/apache/commons/geometry/spherical/twod/GreatArc.java
+++ b/commons-geometry-spherical/src/main/java/org/apache/commons/geometry/spherical/twod/GreatArc.java
@@ -54,8 +54,8 @@ public final class GreatArc extends GreatCircleSubset implements HyperplaneConve
         this.interval = interval;
     }
 
-    /** Return the start point of the arc, or null if the arc represents the full space.
-     * @return the start point of the arc, or null if the arc represents the full space.
+    /** Return the start point of the arc, or {@code null} if the arc represents the full space.
+     * @return the start point of the arc, or {@code null} if the arc represents the full space.
      */
     public Point2S getStartPoint() {
         if (!interval.isFull()) {
@@ -65,8 +65,8 @@ public final class GreatArc extends GreatCircleSubset implements HyperplaneConve
         return null;
     }
 
-    /** Return the end point of the arc, or null if the arc represents the full space.
-     * @return the end point of the arc, or null if the arc represents the full space.
+    /** Return the end point of the arc, or {@code null} if the arc represents the full space.
+     * @return the end point of the arc, or {@code null} if the arc represents the full space.
      */
     public Point2S getEndPoint() {
         if (!interval.isFull()) {
@@ -76,8 +76,8 @@ public final class GreatArc extends GreatCircleSubset implements HyperplaneConve
         return null;
     }
 
-    /** Return the midpoint of the arc, or null if the arc represents the full space.
-     * @return the midpoint of the arc, or null if the arc represents the full space.
+    /** Return the midpoint of the arc, or {@code null} if the arc represents the full space.
+     * @return the midpoint of the arc, or {@code null} if the arc represents the full space.
      */
     public Point2S getMidPoint() {
         if (!interval.isFull()) {

--- a/commons-geometry-spherical/src/main/java/org/apache/commons/geometry/spherical/twod/GreatArcPath.java
+++ b/commons-geometry-spherical/src/main/java/org/apache/commons/geometry/spherical/twod/GreatArcPath.java
@@ -55,8 +55,8 @@ public final class GreatArcPath implements BoundarySource2S {
         return arcs;
     }
 
-    /** Get the start arc for the path or null if the path is empty.
-     * @return the start arc for the path or null if the path is empty
+    /** Get the start arc for the path or {@code null} if the path is empty.
+     * @return the start arc for the path or {@code null} if the path is empty
      */
     public GreatArc getStartArc() {
         if (!isEmpty()) {
@@ -65,8 +65,8 @@ public final class GreatArcPath implements BoundarySource2S {
         return null;
     }
 
-    /** Get the end arc for the path or null if the path is empty.
-     * @return the end arc for the path or null if the path is empty
+    /** Get the end arc for the path or {@code null} if the path is empty.
+     * @return the end arc for the path or {@code null} if the path is empty
      */
     public GreatArc getEndArc() {
         if (!isEmpty()) {
@@ -75,7 +75,7 @@ public final class GreatArcPath implements BoundarySource2S {
         return null;
     }
 
-    /** Get the start vertex for the path or null if the path is empty
+    /** Get the start vertex for the path or {@code null} if the path is empty
      * or consists of a single, full arc.
      * @return the start vertex for the path
      */
@@ -84,7 +84,7 @@ public final class GreatArcPath implements BoundarySource2S {
         return (arc != null) ? arc.getStartPoint() : null;
     }
 
-    /** Get the end vertex for the path or null if the path is empty
+    /** Get the end vertex for the path or {@code null} if the path is empty
      * or consists of a single, full arc.
      * @return the end vertex for the path
      */
@@ -265,7 +265,7 @@ public final class GreatArcPath implements BoundarySource2S {
      * context. The precision context is used when building arcs from points
      * and may be omitted if raw points are not used.
      * @param precision precision context to use when building arcs from
-     *      raw points; may be null if raw points are not used.
+     *      raw points; may be {@code null} if raw points are not used.
      * @return a new {@link Builder} instance
      */
     public static Builder builder(final Precision.DoubleEquivalence precision) {
@@ -324,7 +324,7 @@ public final class GreatArcPath implements BoundarySource2S {
             return this;
         }
 
-        /** Get the arc at the start of the path or null if it does not exist.
+        /** Get the arc at the start of the path or {@code null} if it does not exist.
          * @return the arc at the start of the path
          */
         public GreatArc getStartArc() {
@@ -335,7 +335,7 @@ public final class GreatArcPath implements BoundarySource2S {
             return start;
         }
 
-        /** Get the arc at the end of the path or null if it does not exist.
+        /** Get the arc at the end of the path or {@code null} if it does not exist.
          * @return the arc at the end of the path
          */
         public GreatArc getEndArc() {
@@ -569,7 +569,7 @@ public final class GreatArcPath implements BoundarySource2S {
 
         /** Validate that the given arcs are connected, meaning that the end point of {@code previous}
          * is equivalent to the start point of {@code next}. The arcs are considered valid if either
-         * arc is null.
+         * arc is {@code null}.
          * @param previous previous arc
          * @param next next arc
          * @throws IllegalStateException if previous and next are not null and the end point of previous
@@ -642,10 +642,10 @@ public final class GreatArcPath implements BoundarySource2S {
             prependedArcs.add(arc);
         }
 
-        /** Get the first element in the list or null if the list is null
+        /** Get the first element in the list or {@code null} if the list is {@code null}
          * or empty.
          * @param list the list to return the first item from
-         * @return the first item from the given list or null if it does not exist
+         * @return the first item from the given list or {@code null} if it does not exist
          */
         private GreatArc getFirst(final List<GreatArc> list) {
             if (list != null && !list.isEmpty()) {
@@ -654,10 +654,10 @@ public final class GreatArcPath implements BoundarySource2S {
             return null;
         }
 
-        /** Get the last element in the list or null if the list is null
+        /** Get the last element in the list or {@code null} if the list is {@code null}
          * or empty.
          * @param list the list to return the last item from
-         * @return the last item from the given list or null if it does not exist
+         * @return the last item from the given list or {@code null} if it does not exist
          */
         private GreatArc getLast(final List<GreatArc> list) {
             if (list != null && !list.isEmpty()) {

--- a/commons-geometry-spherical/src/main/java/org/apache/commons/geometry/spherical/twod/GreatCircle.java
+++ b/commons-geometry-spherical/src/main/java/org/apache/commons/geometry/spherical/twod/GreatCircle.java
@@ -256,7 +256,7 @@ public final class GreatCircle extends AbstractHyperplane<Point2S>
 
     /** Return one of the two intersection points between this instance and the argument.
      * If the circles occupy the same space (ie, their poles are parallel or anti-parallel),
-     * then null is returned. Otherwise, the intersection located at the cross product of
+     * then {@code null} is returned. Otherwise, the intersection located at the cross product of
      * the pole of this instance and that of the argument is returned (ie, {@code thisPole.cross(otherPole)}).
      * The other intersection point of the pair is antipodal to this point.
      * @param other circle to intersect with

--- a/commons-geometry-spherical/src/main/java/org/apache/commons/geometry/spherical/twod/Point2S.java
+++ b/commons-geometry-spherical/src/main/java/org/apache/commons/geometry/spherical/twod/Point2S.java
@@ -85,7 +85,7 @@ public final class Point2S implements Point<Point2S> {
     /** Build a point from its internal components.
      * @param azimuth azimuthal angle in the x-y plane
      * @param polar polar angle
-     * @param vector corresponding vector; if null, the vector is computed
+     * @param vector corresponding vector; if {@code null}, the vector is computed
      */
     private Point2S(final double azimuth, final double polar, final Vector3D.Unit vector) {
         this.azimuth = SphericalCoordinates.normalizeAzimuth(azimuth);
@@ -112,7 +112,7 @@ public final class Point2S implements Point<Point2S> {
     }
 
     /** Get the corresponding normalized vector in 3D Euclidean space.
-     * This value will be null if the spherical coordinates of the point
+     * This value will be {@code null} if the spherical coordinates of the point
      * are infinite or NaN.
      * @return normalized vector
      */
@@ -225,7 +225,7 @@ public final class Point2S implements Point<Point2S> {
      *
      * @param other Object to test for equality to this
      * @return true if two points on the 2-sphere objects are exactly equal, false if
-     *         object is null, not an instance of Point2S, or
+     *         object is {@code null}, not an instance of Point2S, or
      *         not equal to this Point2S instance
      */
     @Override
@@ -294,11 +294,11 @@ public final class Point2S implements Point<Point2S> {
     }
 
     /** Compute the 3D Euclidean vector associated with the given spherical coordinates.
-     * Null is returned if the coordinates are infinite or NaN.
+     * {@code null} is returned if the coordinates are infinite or NaN.
      * @param azimuth azimuth value
      * @param polar polar value
      * @return the 3D Euclidean vector associated with the given spherical coordinates
-     *      or null if either of the arguments are infinite or NaN.
+     *      or {@code null} if either of the arguments are infinite or NaN.
      */
     private static Vector3D.Unit computeVector(final double azimuth, final double polar) {
         if (Double.isFinite(azimuth) && Double.isFinite(polar)) {


### PR DESCRIPTION
Enhances existing classes' JavaDoc towards better readability by highlighting the 'null' token in text.