### PR TITLE
reject new line characters in obj writer object and group names

### DIFF
--- a/commons-geometry-io-euclidean/src/main/java/org/apache/commons/geometry/io/euclidean/threed/obj/ObjWriter.java
+++ b/commons-geometry-io-euclidean/src/main/java/org/apache/commons/geometry/io/euclidean/threed/obj/ObjWriter.java
@@ -86,9 +86,11 @@ public final class ObjWriter extends AbstractTextFormatWriter {
      * does not affect the geometry, although it may affect how the file content
      * is read by other programs.
      * @param objectName the name to write
+     * @throws IllegalArgumentException if {@code objectName} contains new line characters
      * @throws java.io.UncheckedIOException if an I/O error occurs
      */
     public void writeObjectName(final String objectName) {
+        checkName("Object", objectName);
         writeKeywordLine(ObjConstants.OBJECT_KEYWORD, objectName);
     }
 
@@ -96,9 +98,11 @@ public final class ObjWriter extends AbstractTextFormatWriter {
      * does not affect the geometry, although it may affect how the file content
      * is read by other programs.
      * @param groupName the name to write
+     * @throws IllegalArgumentException if {@code groupName} contains new line characters
      * @throws java.io.UncheckedIOException if an I/O error occurs
      */
     public void writeGroupName(final String groupName) {
+        checkName("Group", groupName);
         writeKeywordLine(ObjConstants.GROUP_KEYWORD, groupName);
     }
 
@@ -337,6 +341,19 @@ public final class ObjWriter extends AbstractTextFormatWriter {
         write(SPACE);
         write(content);
         writeNewLine();
+    }
+
+    /** Throw an exception if the given name contains new line characters. Names are written on a
+     * single line, so an embedded new line would let the trailing content be interpreted as
+     * additional OBJ statements.
+     * @param type type of name being checked; used in the error message
+     * @param name name to check; may be null
+     * @throws IllegalArgumentException if {@code name} contains a '\r' or '\n' character
+     */
+    private static void checkName(final String type, final String name) {
+        if (name != null && (name.indexOf('\r') > -1 || name.indexOf('\n') > -1)) {
+            throw new IllegalArgumentException(type + " name cannot contain new line characters");
+        }
     }
 
     /** Class used to produce OBJ mesh content from sequences of facets. As facets are added to the buffer

--- a/commons-geometry-io-euclidean/src/test/java/org/apache/commons/geometry/io/euclidean/threed/obj/ObjWriterTest.java
+++ b/commons-geometry-io-euclidean/src/test/java/org/apache/commons/geometry/io/euclidean/threed/obj/ObjWriterTest.java
@@ -154,6 +154,52 @@ class ObjWriterTest {
     }
 
     @Test
+    void testWriteObjectName_containsNewLine() {
+        // arrange
+        final StringWriter writer = new StringWriter();
+
+        // act/assert
+        try (ObjWriter objWriter = new ObjWriter(writer)) {
+            final String err = "Object name cannot contain new line characters";
+
+            GeometryTestUtils.assertThrowsWithMessage(
+                    () -> objWriter.writeObjectName("a\nv 0 0 0"),
+                    IllegalArgumentException.class, err);
+            GeometryTestUtils.assertThrowsWithMessage(
+                    () -> objWriter.writeObjectName("a\r\nv 0 0 0"),
+                    IllegalArgumentException.class, err);
+            GeometryTestUtils.assertThrowsWithMessage(
+                    () -> objWriter.writeObjectName("a\rv 0 0 0"),
+                    IllegalArgumentException.class, err);
+        }
+
+        Assertions.assertEquals("", writer.getBuffer().toString());
+    }
+
+    @Test
+    void testWriteGroupName_containsNewLine() {
+        // arrange
+        final StringWriter writer = new StringWriter();
+
+        // act/assert
+        try (ObjWriter objWriter = new ObjWriter(writer)) {
+            final String err = "Group name cannot contain new line characters";
+
+            GeometryTestUtils.assertThrowsWithMessage(
+                    () -> objWriter.writeGroupName("a\nv 0 0 0"),
+                    IllegalArgumentException.class, err);
+            GeometryTestUtils.assertThrowsWithMessage(
+                    () -> objWriter.writeGroupName("a\r\nv 0 0 0"),
+                    IllegalArgumentException.class, err);
+            GeometryTestUtils.assertThrowsWithMessage(
+                    () -> objWriter.writeGroupName("a\rv 0 0 0"),
+                    IllegalArgumentException.class, err);
+        }
+
+        Assertions.assertEquals("", writer.getBuffer().toString());
+    }
+
+    @Test
     void testWriteVertex() {
         // arrange
         final StringWriter writer = new StringWriter();


### PR DESCRIPTION
writeObjectName and writeGroupName write the name straight onto the o/g line, so a name with a \r or \n breaks out of that line and the rest is read back as separate OBJ statements (injected vertices/faces, or an mtllib pulling in an arbitrary material file). TextStlWriter.startSolid already guards its solid name against new lines; this adds the same check to the two ObjWriter name methods so the writer can't emit a name that re-parses as geometry. What happens if the name comes from user-supplied metadata is the case I had in mind here.